### PR TITLE
Add LinkML-first FastAPI API scaffold for studies/experiments

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,5 @@
+"""ZAPP Atlas server package.
+
+We keep this lightweight; its primary purpose is to make imports work from the
+repository root (e.g. `from server.api.main import app`).
+"""

--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -1,0 +1,6 @@
+"""FastAPI application package.
+
+This package is the new (non-legacy) API surface for zapp-atlas.
+
+The legacy Flask server lives in `server/main.py` and should not be modified.
+"""

--- a/server/api/deps.py
+++ b/server/api/deps.py
@@ -1,0 +1,25 @@
+"""FastAPI dependencies (database sessions, etc.)."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+from sqlalchemy.orm import Session
+
+from server.db import get_engine, get_session_factory
+
+
+# In production we may want more explicit lifecycle management, but for now
+# having a module-level engine is fine.
+_engine = get_engine()
+_SessionLocal = get_session_factory(_engine)
+
+
+def get_session() -> Generator[Session, None, None]:
+    """Yield a SQLAlchemy session and ensure it is closed."""
+
+    session: Session = _SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -1,0 +1,32 @@
+"""FastAPI entrypoint for the ZAPP Atlas API.
+
+Notes
+-----
+* This is intended to replace the legacy Flask server in `server/main.py`.
+* For now this module focuses on the "LinkML-first" JSON API (e.g. /studies).
+* The LinkML-generated models are imported from the schema package.
+"""
+
+from fastapi import FastAPI
+
+from server.api.routers.experiments import router as experiments_router
+from server.api.routers.studies import router as studies_router
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="ZAPP Atlas API",
+        version="0.1.0",
+    )
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.include_router(studies_router)
+    app.include_router(experiments_router)
+    return app
+
+
+# Uvicorn entrypoint (once wired): `uvicorn server.api.main:app --reload`
+app = create_app()

--- a/server/api/routers/__init__.py
+++ b/server/api/routers/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI routers."""

--- a/server/api/routers/experiments.py
+++ b/server/api/routers/experiments.py
@@ -1,0 +1,73 @@
+"""Experiment endpoints.
+
+Creation is scoped to a Study (no orphan experiments yet):
+
+* POST /studies/{study_id}/experiments
+
+Reading/listing is via a top-level experiments resource:
+
+* GET /experiments
+* GET /experiments/{experiment_id}
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from server.api.deps import get_session
+from server.api.services.experiments import (
+    create_experiment_for_study,
+    get_experiment_by_id,
+    list_experiments,
+)
+
+from zebrafish_toxicology_atlas_schema.datamodel.pydanticmodel_v2 import (
+    ExperimentCreate,
+    ExperimentRead,
+)
+
+
+router = APIRouter(tags=["experiments"])
+
+
+@router.post(
+    "/studies/{study_id}/experiments",
+    response_model=ExperimentRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_experiment_for_study_endpoint(
+    study_id: int,
+    payload: ExperimentCreate,
+    session: Annotated[Session, Depends(get_session)],
+) -> ExperimentRead:
+    exp = create_experiment_for_study(session, study_id=study_id, payload=payload)
+    if exp is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Study not found")
+    return exp  # type: ignore[return-value]
+
+
+@router.get("/experiments", response_model=list[ExperimentRead])
+def list_experiments_endpoint(
+    session: Annotated[Session, Depends(get_session)],
+    limit: int = 50,
+    offset: int = 0,
+) -> list[ExperimentRead]:
+    rows = list_experiments(session, limit=limit, offset=offset)
+    return rows  # type: ignore[return-value]
+
+
+@router.get("/experiments/{experiment_id}", response_model=ExperimentRead)
+def get_experiment_endpoint(
+    experiment_id: int,
+    session: Annotated[Session, Depends(get_session)],
+) -> ExperimentRead:
+    exp = get_experiment_by_id(session, experiment_id)
+    if exp is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Experiment not found",
+        )
+    return exp  # type: ignore[return-value]

--- a/server/api/routers/studies.py
+++ b/server/api/routers/studies.py
@@ -1,0 +1,73 @@
+"""Study CRUD endpoints.
+
+This router is intentionally thin: all persistence/mapping details are pushed
+into `api.services.studies`.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from server.api.deps import get_session
+from server.api.services.studies import (
+    create_study,
+    get_study_by_id,
+    list_studies,
+    patch_study,
+)
+
+# LinkML-generated Pydantic CRUD models
+from zebrafish_toxicology_atlas_schema.datamodel.pydanticmodel_v2 import (
+    StudyCreate,
+    StudyRead,
+    StudyUpdate,
+)
+
+
+router = APIRouter(prefix="/studies", tags=["studies"])
+
+
+@router.post("", response_model=StudyRead, status_code=status.HTTP_201_CREATED)
+def create_study_endpoint(
+    payload: StudyCreate,
+    session: Annotated[Session, Depends(get_session)],
+) -> StudyRead:
+    study = create_study(session, payload)
+    # We return ORM instances; StudyRead is configured with from_attributes=True.
+    return study  # type: ignore[return-value]
+
+
+@router.get("/{study_id}", response_model=StudyRead)
+def get_study_endpoint(
+    study_id: int,
+    session: Annotated[Session, Depends(get_session)],
+) -> StudyRead:
+    study = get_study_by_id(session, study_id)
+    if study is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Study not found")
+    return study  # type: ignore[return-value]
+
+
+@router.get("", response_model=list[StudyRead])
+def list_studies_endpoint(
+    session: Annotated[Session, Depends(get_session)],
+    limit: int = 50,
+    offset: int = 0,
+) -> list[StudyRead]:
+    rows = list_studies(session, limit=limit, offset=offset)
+    return rows  # type: ignore[return-value]
+
+
+@router.patch("/{study_id}", response_model=StudyRead)
+def patch_study_endpoint(
+    study_id: int,
+    patch: StudyUpdate,
+    session: Annotated[Session, Depends(get_session)],
+) -> StudyRead:
+    study = patch_study(session, study_id, patch)
+    if study is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Study not found")
+    return study  # type: ignore[return-value]

--- a/server/api/services/__init__.py
+++ b/server/api/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer for API endpoints.
+
+This package contains business logic and mapping between LinkML-generated
+Pydantic models and LinkML-generated SQLAlchemy models.
+"""

--- a/server/api/services/experiments.py
+++ b/server/api/services/experiments.py
@@ -1,0 +1,54 @@
+"""Experiment persistence + mapping.
+
+We treat Experiment as the main unit of submission, with creation scoped to a
+Study container.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from server.api.services.studies import _experiment_from_create
+
+from zebrafish_toxicology_atlas_schema.datamodel.pydanticmodel_v2 import ExperimentCreate
+
+from zebrafish_toxicology_atlas_schema.datamodel.sqla import (  # type: ignore
+    Experiment,
+    Study,
+)
+
+
+def create_experiment_for_study(
+    session: Session,
+    *,
+    study_id: int,
+    payload: ExperimentCreate,
+) -> Optional[Experiment]:
+    """Create an Experiment belonging to an existing Study."""
+
+    study = session.get(Study, study_id)
+    if study is None:
+        return None
+
+    exp = _experiment_from_create(session, payload)
+    # Associate with parent container
+    study.experiment.append(exp)
+
+    session.add(study)
+    session.commit()
+    session.refresh(exp)
+    return exp
+
+
+def get_experiment_by_id(session: Session, experiment_id: int) -> Optional[Experiment]:
+    try:
+        return session.get(Experiment, experiment_id)
+    except Exception:
+        return session.query(Experiment).filter(Experiment.id == experiment_id).one_or_none()
+
+
+def list_experiments(session: Session, *, limit: int = 50, offset: int = 0) -> list[Experiment]:
+    q = session.query(Experiment).order_by(Experiment.id).offset(offset).limit(limit)
+    return list(q)

--- a/server/api/services/studies.py
+++ b/server/api/services/studies.py
@@ -1,0 +1,249 @@
+"""Study persistence + mapping.
+
+The intent here is to keep all of the "how do I convert StudyCreate to ORM"
+logic in one place, so the router stays clean.
+
+This code assumes LinkML-generated SQLAlchemy ORM classes are available at:
+`zebrafish_toxicology_atlas_schema.datamodel.sqla`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from zebrafish_toxicology_atlas_schema.datamodel.pydanticmodel_v2 import (
+    ControlCreate,
+    ExposureEventCreate,
+    ExperimentCreate,
+    PhenotypeCreate,
+    PhenotypeObservationSetCreate,
+    RegimenCreate,
+    StressorChemicalCreate,
+    StudyCreate,
+    StudyUpdate,
+)
+
+# LinkML-generated SQLAlchemy models (present on another branch per user).
+from zebrafish_toxicology_atlas_schema.datamodel.sqla import (  # type: ignore
+    ChemicalEntity,
+    Control,
+    ExposureEvent,
+    Experiment,
+    Fish,
+    Phenotype,
+    PhenotypeObservationSet,
+    PhenotypeTerm,
+    QuantityValue,
+    Regimen,
+    StressorChemical,
+    Study,
+)
+
+
+def _get_or_create_by_attrs(session: Session, model, /, **attrs):
+    """Best-effort get-or-create helper.
+
+    We intentionally keep this simple because the schema/ORM may still be in
+    flux (and may move into this repository).
+    """
+
+    instance = session.query(model).filter_by(**attrs).one_or_none()
+    if instance is not None:
+        return instance
+    instance = model(**attrs)
+    session.add(instance)
+    return instance
+
+
+def _quantity_value_from_payload(payload: QuantityValue | None) -> QuantityValue | None:
+    if payload is None:
+        return None
+    # QuantityValue is both a Pydantic model and an ORM class name; here we
+    # assume payload is the Pydantic version and construct ORM version.
+    return QuantityValue(
+        unit=getattr(payload, "unit", None),
+        numeric_value=getattr(payload, "numeric_value", None),
+    )
+
+
+def _fish_from_payload(session: Session, payload: Fish | None) -> Fish | None:
+    if payload is None:
+        return None
+    # Fish has a natural identifier (zfin_id). Prefer upsert semantics.
+    try:
+        return _get_or_create_by_attrs(session, Fish, zfin_id=payload.zfin_id, name=payload.name)
+    except Exception:
+        # Fall back to naive instance creation if constraints differ.
+        return Fish(zfin_id=payload.zfin_id, name=payload.name)
+
+
+def _phenotype_term_from_payload(session: Session, payload: PhenotypeTerm | None) -> PhenotypeTerm | None:
+    if payload is None:
+        return None
+    try:
+        return _get_or_create_by_attrs(
+            session,
+            PhenotypeTerm,
+            term_uri=payload.term_uri,
+            term_label=getattr(payload, "term_label", None),
+        )
+    except Exception:
+        return PhenotypeTerm(term_uri=payload.term_uri, term_label=getattr(payload, "term_label", None))
+
+
+def _chemical_entity_from_payload(session: Session, payload: ChemicalEntity | None) -> ChemicalEntity | None:
+    if payload is None:
+        return None
+
+    # NOTE: Depending on the ORM primary key definition, this may need
+    # adjustment. This is intentionally best-effort.
+    attrs = {
+        "uri": payload.uri,
+        "chebi_id": getattr(payload, "chebi_id", None),
+        "cas_id": getattr(payload, "cas_id", None),
+        "chemical_name": getattr(payload, "chemical_name", None),
+    }
+    try:
+        return _get_or_create_by_attrs(session, ChemicalEntity, **attrs)
+    except Exception:
+        return ChemicalEntity(**attrs)
+
+
+def _stressor_from_create(session: Session, payload: StressorChemicalCreate) -> StressorChemical:
+    chemical = _chemical_entity_from_payload(session, payload.chemical_id)
+    concentration = _quantity_value_from_payload(payload.concentration)
+    return StressorChemical(
+        chemical_id=chemical,
+        concentration=concentration,
+        manufacturer=payload.manufacturer,
+        comment=getattr(payload, "comment", None),
+    )
+
+
+def _phenotype_from_create(session: Session, payload: PhenotypeCreate) -> Phenotype:
+    prevalence = _quantity_value_from_payload(getattr(payload, "prevalence", None))
+    phenotype_term = _phenotype_term_from_payload(session, getattr(payload, "phenotype_term_id", None))
+    return Phenotype(
+        stage=payload.stage,
+        severity=getattr(payload, "severity", None),
+        prevalence=prevalence,
+        phenotype_term_id=phenotype_term,
+    )
+
+
+def _obs_set_from_create(session: Session, payload: PhenotypeObservationSetCreate) -> PhenotypeObservationSet:
+    obs = PhenotypeObservationSet()
+    for ph in payload.phenotype or []:
+        obs.phenotype.append(_phenotype_from_create(session, ph))
+    # Images and control images intentionally omitted for now.
+    return obs
+
+
+def _regimen_from_create(session: Session, payload: RegimenCreate | None) -> Regimen | None:
+    if payload is None:
+        return None
+    return Regimen(
+        exposure_regimen_type=getattr(payload, "exposure_regimen_type", None),
+        number_of_individual_exposure=getattr(payload, "number_of_individual_exposure", None),
+        interval_between_individual_exposures=_quantity_value_from_payload(
+            getattr(payload, "interval_between_individual_exposures", None)
+        ),
+        total_exposure_duration=_quantity_value_from_payload(getattr(payload, "total_exposure_duration", None)),
+        individual_exposure_duration=_quantity_value_from_payload(
+            getattr(payload, "individual_exposure_duration", None)
+        ),
+    )
+
+
+def _exposure_event_from_create(session: Session, payload: ExposureEventCreate) -> ExposureEvent:
+    ee = ExposureEvent(
+        vehicle=payload.vehicle,
+        route=payload.route,
+        exposure_start_stage=payload.exposure_start_stage,
+        exposure_end_stage=payload.exposure_end_stage,
+        comment=getattr(payload, "comment", None),
+        exposure_type=getattr(payload, "exposure_type", None),
+        additional_exposure_condition=getattr(payload, "additional_exposure_condition", None),
+        regimen=_regimen_from_create(session, getattr(payload, "regimen", None)),
+    )
+    for s in payload.stressor or []:
+        ee.stressor.append(_stressor_from_create(session, s))
+    for obs in payload.phenotype_observation or []:
+        ee.phenotype_observation.append(_obs_set_from_create(session, obs))
+    return ee
+
+
+def _control_from_create(payload: ControlCreate) -> Control:
+    return Control(
+        control_type=payload.control_type,
+        vehicle_if_treated=getattr(payload, "vehicle_if_treated", None),
+        comment=getattr(payload, "comment", None),
+    )
+
+
+def _experiment_from_create(session: Session, payload: ExperimentCreate) -> Experiment:
+    exp = Experiment(
+        standard_rearing_condition=payload.standard_rearing_condition,
+        rearing_condition_comment=getattr(payload, "rearing_condition_comment", None),
+        fish=_fish_from_payload(session, getattr(payload, "fish", None)),
+    )
+    for c in payload.control or []:
+        exp.control.append(_control_from_create(c))
+    for ee in payload.exposure_event or []:
+        exp.exposure_event.append(_exposure_event_from_create(session, ee))
+    return exp
+
+
+def _study_from_create(session: Session, payload: StudyCreate) -> Study:
+    study = Study(
+        publication=payload.publication,
+        lab=payload.lab,
+    )
+    # association_proxy list assignment should work for annotator
+    if payload.annotator is not None:
+        study.annotator = payload.annotator
+    for exp_payload in payload.experiment or []:
+        study.experiment.append(_experiment_from_create(session, exp_payload))
+    return study
+
+
+def create_study(session: Session, payload: StudyCreate) -> Study:
+    study = _study_from_create(session, payload)
+    session.add(study)
+    session.commit()
+    session.refresh(study)
+    return study
+
+
+def get_study_by_id(session: Session, study_id: int) -> Optional[Study]:
+    # SQLAlchemy 1.4/2.0: Session.get is preferred.
+    try:
+        return session.get(Study, study_id)
+    except Exception:
+        return session.query(Study).filter(Study.id == study_id).one_or_none()
+
+
+def list_studies(session: Session, *, limit: int = 50, offset: int = 0) -> list[Study]:
+    q = session.query(Study).order_by(Study.id).offset(offset).limit(limit)
+    return list(q)
+
+
+def patch_study(session: Session, study_id: int, patch: StudyUpdate) -> Optional[Study]:
+    study = get_study_by_id(session, study_id)
+    if study is None:
+        return None
+
+    # NOTE: This is deliberately a shallow patch for now.
+    if patch.publication is not None:
+        study.publication = patch.publication
+    if patch.lab is not None:
+        study.lab = patch.lab
+    if patch.annotator is not None:
+        study.annotator = patch.annotator
+
+    session.add(study)
+    session.commit()
+    session.refresh(study)
+    return study

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -5,9 +5,12 @@ description = "Server for the ZAPP atlas"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "fastapi>=0.135.1",
     "flask>=3.1.2",
+    "httpx>=0.27.0",
     "sqlalchemy>=2.0",
-    "zebrafish-toxicology-atlas-schema @ git+https://github.com/zappfish/zebrafish-toxicology-atlas-schema.git@sqlalchemy-and-minor-tweaks",
+    "uvicorn>=0.30.0",
+    "zebrafish-toxicology-atlas-schema @ git+https://github.com/zappfish/zebrafish-toxicology-atlas-schema.git@pydantic-crud-models",
 ]
 
 [dependency-groups]
@@ -16,4 +19,4 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-pythonpath = ["."]
+pythonpath = [".."]

--- a/server/tests/test_api_experiments.py
+++ b/server/tests/test_api_experiments.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""API tests for Experiment endpoints."""
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from server.api.deps import get_session
+from server.api.main import create_app
+
+
+def _make_test_app():
+    from zebrafish_toxicology_atlas_schema.datamodel.sqla import Base  # type: ignore
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    app = create_app()
+
+    def _override_get_session():
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_session] = _override_get_session
+    return app
+
+
+def _create_study(client: TestClient) -> int:
+    payload = {
+        "publication": "PMID:123456",
+        "lab": "ZFIN:ZDB-LAB-1-1",
+        "annotator": ["ORCID:0000-0000-0000-0000"],
+        "experiment": [],
+    }
+    res = client.post("/studies", json=payload)
+    assert res.status_code == 201, res.text
+    return res.json()["id"]
+
+
+def test_experiment_create_for_study_then_get_and_list():
+    app = _make_test_app()
+    client = TestClient(app)
+
+    study_id = _create_study(client)
+
+    exp_payload = {
+        "standard_rearing_condition": True,
+        "rearing_condition_comment": "",
+        "fish": {
+            "zfin_id": "ZFIN:ZDB-GENO-960809-7",
+            "name": "AB",
+        },
+        "control": [],
+        "exposure_event": [],
+    }
+
+    create_res = client.post(f"/studies/{study_id}/experiments", json=exp_payload)
+    assert create_res.status_code == 201, create_res.text
+    created = create_res.json()
+    assert "id" in created
+
+    get_res = client.get(f"/experiments/{created['id']}")
+    assert get_res.status_code == 200, get_res.text
+    got = get_res.json()
+    assert got["id"] == created["id"]
+
+    list_res = client.get("/experiments")
+    assert list_res.status_code == 200, list_res.text
+    rows = list_res.json()
+    assert any(r["id"] == created["id"] for r in rows)
+
+
+def test_experiment_create_missing_study_404():
+    app = _make_test_app()
+    client = TestClient(app)
+
+    exp_payload = {
+        "standard_rearing_condition": True,
+        "fish": {
+            "zfin_id": "ZFIN:ZDB-GENO-960809-7",
+            "name": "AB",
+        },
+        "control": [],
+        "exposure_event": [],
+    }
+    res = client.post("/studies/999999/experiments", json=exp_payload)
+    assert res.status_code == 404
+
+
+def test_experiment_get_missing_404():
+    app = _make_test_app()
+    client = TestClient(app)
+
+    res = client.get("/experiments/999999")
+    assert res.status_code == 404

--- a/server/tests/test_api_health.py
+++ b/server/tests/test_api_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from server.api.main import create_app
+
+
+def test_health():
+    client = TestClient(create_app())
+    res = client.get("/health")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}

--- a/server/tests/test_api_studies.py
+++ b/server/tests/test_api_studies.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+"""API tests for the FastAPI Study endpoints.
+
+These tests are intended to validate the FastAPI wiring + basic CRUD semantics.
+
+Note: per project direction, these may not run yet until:
+* the schema package is vendored into this repo and import paths stabilize
+* SQLAlchemy models are available on this branch
+* dependencies like uvicorn/httpx are installed
+"""
+
+import pytest
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from server.api.deps import get_session
+from server.api.main import create_app
+
+
+def _make_test_app():
+    """Create an app instance configured with an in-memory sqlite session."""
+
+    # Schema-provided SQLAlchemy base (assumed to exist)
+    from zebrafish_toxicology_atlas_schema.datamodel.sqla import Base  # type: ignore
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    app = create_app()
+
+    def _override_get_session():
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_session] = _override_get_session
+    return app
+
+
+def test_study_create_then_get_round_trip_minimal():
+    app = _make_test_app()
+    client = TestClient(app)
+
+    payload = {
+        "publication": "PMID:123456",
+        "lab": "ZFIN:ZDB-LAB-1-1",
+        "annotator": ["ORCID:0000-0000-0000-0000"],
+        "experiment": [],
+    }
+    create_res = client.post("/studies", json=payload)
+    assert create_res.status_code == 201, create_res.text
+    created = create_res.json()
+    assert "id" in created
+
+    get_res = client.get(f"/studies/{created['id']}")
+    assert get_res.status_code == 200, get_res.text
+    got = get_res.json()
+    assert got["id"] == created["id"]
+
+
+def test_study_get_missing_404():
+    app = _make_test_app()
+    client = TestClient(app)
+
+    res = client.get("/studies/999999")
+    assert res.status_code == 404
+
+
+def test_study_patch_updates_top_level_fields():
+    app = _make_test_app()
+    client = TestClient(app)
+
+    create_payload = {
+        "publication": "PMID:123456",
+        "lab": "ZFIN:ZDB-LAB-1-1",
+        "annotator": ["ORCID:0000-0000-0000-0000"],
+        "experiment": [],
+    }
+    created = client.post("/studies", json=create_payload).json()
+
+    patch_payload = {
+        "publication": "PMID:654321",
+    }
+    patch_res = client.patch(f"/studies/{created['id']}", json=patch_payload)
+    assert patch_res.status_code == 200, patch_res.text
+    patched = patch_res.json()
+    assert patched["publication"] == "PMID:654321"


### PR DESCRIPTION
- Add new FastAPI app under server/api (legacy Flask server/main.py unchanged)
- Implement Study endpoints: POST/GET/LIST/PATCH /studies
- Implement Experiment endpoints: POST /studies/{id}/experiments and GET /experiments(+/{id})
- Add service layer for mapping Create models -> SQLAlchemy ORM and persistence
- Add API tests for health, studies, and experiments using TestClient + DB override
- Update server deps metadata (uvicorn, httpx)
- Make server/ a Python package and switch imports to server.* for repo-root execution
- Refresh root docs: move old README to README_legacy.md and rewrite README.md

Still TODO: moving the schema into this repository. Nothing is running until then.