### PR TITLE
Add deployment setup (Fly.io + temporary GCP Cloud Run) and fix dev server imports

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+node_modules
+client/dist
+client/node_modules
+server/.venv
+server/data
+*.db
+__pycache__
+docs
+*.pyc
+.pytest_cache
+.mypy_cache
+.ruff_cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 dist
 tsconfig.tsbuildinfo
 __pycache__/
+.env.local
 
 # Server secrets and uploads
 server/credentials.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Stage 1 — Build the React frontend
+FROM node:20-slim AS frontend
+
+WORKDIR /build
+COPY client/package.json client/package-lock.json ./
+RUN npm ci
+COPY client/ ./
+RUN npm run build
+
+# Stage 2 — Python runtime
+FROM python:3.12-slim AS runtime
+
+# git is required for the git-based schema dependency
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app
+
+# Install Python dependencies (cached layer)
+COPY server/pyproject.toml server/uv.lock ./server/
+RUN cd server && uv sync --frozen --no-dev
+
+# Copy server source code
+COPY server/ ./server/
+
+# Copy built frontend from stage 1
+COPY --from=frontend /build/dist/ ./client/dist/
+
+ENV PYTHONPATH=/app
+
+EXPOSE 8080
+
+CMD ["uv", "run", "--no-sync", "--directory", "server", \
+     "uvicorn", "server.api.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /build
 COPY client/package.json client/package-lock.json ./
 RUN npm ci
 COPY client/ ./
+ARG VITE_DATA_BASE_URL
 RUN npm run build
 
 # Stage 2 — Python runtime

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,31 @@
+set dotenv-load := true
+set dotenv-filename := ".env.local"
+
+api_port := env("API_PORT", "8000")
+dev_port := env("DEV_PORT", "5173")
+
+# List available recipes
+default:
+    @just --list
+
+# Run the FastAPI backend
+dev-api:
+    cd server && PYTHONPATH=.. uv run uvicorn server.api.main:app --reload --port {{api_port}}
+
+# Run the Vite dev server
+dev-client:
+    cd client && npm run dev
+
+# Run both API and client (requires two terminals)
+dev:
+    @echo "Run in two terminals:"
+    @echo "  just dev-api     # FastAPI on :{{api_port}}"
+    @echo "  just dev-client  # Vite on :{{dev_port}}"
+
+# Run Python tests
+test:
+    cd server && uv run pytest
+
+# Build the Docker image
+build:
+    docker build -t zapp-atlas .

--- a/Justfile
+++ b/Justfile
@@ -26,6 +26,48 @@ dev:
 test:
     cd server && uv run pytest
 
-# Build the Docker image
+# Build the Docker image (local/Fly.io)
 build:
     docker build -t zapp-atlas .
+
+# --- GCP Cloud Run ---
+
+gcp_project := "monarch-initiative"
+gcp_region := "us-central1"
+gcp_image := "us-central1-docker.pkg.dev/" + gcp_project + "/cloud-run-source-deploy/zapp-atlas:latest"
+gcp_bucket := "zapp-atlas-data"
+gcp_data_url := "https://storage.googleapis.com/" + gcp_bucket + "/public/data"
+
+# Build and push the Docker image for GCP
+gcp-build:
+    docker buildx build --platform linux/amd64 \
+      --build-arg "VITE_DATA_BASE_URL={{gcp_data_url}}" \
+      -t {{gcp_image}} .
+    docker push {{gcp_image}}
+
+# Deploy to Cloud Run
+gcp-deploy:
+    gcloud run deploy zapp-atlas \
+      --image {{gcp_image}} \
+      --project {{gcp_project}} \
+      --region {{gcp_region}} \
+      --execution-environment gen2 \
+      --max-instances 1 \
+      --set-env-vars ZAPP_DB_PATH=/data/zapp.db,PYTHONPATH=/app \
+      --add-volume name=data,type=cloud-storage,bucket={{gcp_bucket}} \
+      --add-volume-mount volume=data,mount-path=/data
+
+# Build, push, and deploy to GCP in one step
+gcp-ship: gcp-build gcp-deploy
+
+# Show Cloud Run service status and URL
+gcp-status:
+    @gcloud run services describe zapp-atlas \
+      --project {{gcp_project}} \
+      --region {{gcp_region}} \
+      --format="table(status.url, status.conditions[0].status, status.traffic[0].revisionName, status.traffic[0].percent)"
+
+# Upload data files to GCS bucket
+gcp-upload-data:
+    gsutil cp client/public/data/zfa.json gs://{{gcp_bucket}}/public/data/zfa.json
+    gsutil cp client/public/data/zp-zapp.json gs://{{gcp_bucket}}/public/data/zp-zapp.json

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -37,12 +37,14 @@ const zpCache: {
   data: null,
 };
 
+const DATA_BASE = import.meta.env.VITE_DATA_BASE_URL || "data";
+
 async function loadZPData(): Promise<ZPData> {
   const loader = new OBOGraphLoader();
 
   const [zfaGraph, zpGraph] = await Promise.all([
-    loader.fromURI("data/zfa.json"),
-    loader.fromURI("data/zp-zapp.json"),
+    loader.fromURI(`${DATA_BASE}/zfa.json`),
+    loader.fromURI(`${DATA_BASE}/zp-zapp.json`),
   ]);
 
   const zfaHierarchy = zfaGraph.getHierarchy(ZFA_ROOT);

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -12,6 +12,7 @@
       "@/*": ["*"]
     },
 
+    "module": "esnext",
     "moduleResolution": "bundler",
     "strict": true,
     "noEmit": true,
@@ -20,6 +21,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "types": ["react", "react-dom"]
+    "types": ["react", "react-dom", "vite/client"]
   }
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -19,6 +19,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "types": ["react", "react-dom"]
   }
 }

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,20 +1,34 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 
-export default defineConfig(({ mode }) => ({
-  base: mode === "phenodemo" ? "./" : "/",
-  plugins: [react()],
-  resolve: {
-      alias: {
-          '@': path.resolve(__dirname, 'src')
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, path.resolve(__dirname, '..'), '');
+  const apiPort = env.API_PORT || '8000';
+  const apiTarget = `http://localhost:${apiPort}`;
+
+  return {
+    base: mode === "phenodemo" ? "./" : "/",
+    plugins: [react()],
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, 'src')
+        }
+    },
+    server: {
+      port: env.DEV_PORT ? Number(env.DEV_PORT) : 5173,
+      proxy: {
+        '/health': apiTarget,
+        '/studies': apiTarget,
+        '/experiments': apiTarget,
+      },
+    },
+    build: {
+      rollupOptions: {
+        input: mode === "phenodemo"
+          ? { phenodemo: path.resolve(__dirname, "phenodemo.html") }
+          : { main: path.resolve(__dirname, "index.html") },
       }
-  },
-  build: {
-    rollupOptions: {
-      input: mode === "phenodemo"
-        ? { phenodemo: path.resolve(__dirname, "phenodemo.html") }
-        : { main: path.resolve(__dirname, "index.html") },
-    }
-  },
-}));
+    },
+  };
+});

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,30 @@
+app = 'zapp-atlas'
+primary_region = 'sjc'
+
+[build]
+
+[env]
+  ZAPP_DB_PATH = '/data/zapp.db'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = 'requests'
+    hard_limit = 250
+    soft_limit = 200
+
+[[http_service.checks]]
+  grace_period = '10s'
+  interval = '30s'
+  method = 'GET'
+  path = '/health'
+  timeout = '5s'
+
+[mounts]
+  source = 'zapp_data'
+  destination = '/data'

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -7,16 +7,55 @@ Notes
 * The LinkML-generated models are imported from the schema package.
 """
 
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import fastapi._compat.v2 as _fastapi_compat_v2
 from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from server.api.routers.experiments import router as experiments_router
 from server.api.routers.studies import router as studies_router
+from server.db import init_db
+
+
+# ---------------------------------------------------------------------------
+# Patch FastAPI's JSON-schema generator for LinkML-generated "enum" classes.
+#
+# LinkML sometimes emits bare ``str`` subclasses (e.g. ExposureRouteEnum)
+# instead of proper ``enum.Enum`` types.  Pydantic validates them with
+# ``core_schema.is_instance_schema()``, which has no JSON Schema mapping and
+# raises ``PydanticInvalidForJsonSchema``.
+#
+# We subclass FastAPI's own ``GenerateJsonSchema`` (in ``fastapi._compat.v2``)
+# so that any str subclass is emitted as ``{"type": "string"}``, then replace
+# the module-level reference that ``get_definitions`` uses.
+# ---------------------------------------------------------------------------
+class _LenientJsonSchema(_fastapi_compat_v2.GenerateJsonSchema):
+    def is_instance_schema(self, schema: dict) -> dict:  # type: ignore[override]
+        cls = schema.get("cls")
+        if cls is not None and issubclass(cls, str):
+            return {"type": "string"}
+        return super().is_instance_schema(schema)
+
+
+_fastapi_compat_v2.GenerateJsonSchema = _LenientJsonSchema  # type: ignore[misc]
+
+DIST_DIR = Path(__file__).resolve().parent.parent.parent / "client" / "dist"
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    init_db()
+    yield
 
 
 def create_app() -> FastAPI:
     app = FastAPI(
         title="ZAPP Atlas API",
         version="0.1.0",
+        lifespan=lifespan,
     )
 
     @app.get("/health")
@@ -25,6 +64,22 @@ def create_app() -> FastAPI:
 
     app.include_router(studies_router)
     app.include_router(experiments_router)
+
+    # Serve Vite's hashed asset bundles (JS/CSS) if the build exists
+    assets_dir = DIST_DIR / "assets"
+    if assets_dir.is_dir():
+        app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
+
+    # SPA catch-all: serve files from dist/ if they exist, otherwise index.html
+    if DIST_DIR.is_dir():
+
+        @app.get("/{full_path:path}")
+        async def spa_catch_all(full_path: str):
+            file = DIST_DIR / full_path
+            if full_path and file.is_file():
+                return FileResponse(file)
+            return FileResponse(DIST_DIR / "index.html")
+
     return app
 
 

--- a/server/tests/test_api_experiments.py
+++ b/server/tests/test_api_experiments.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from server.api.deps import get_session
 from server.api.main import create_app
@@ -13,7 +14,11 @@ from server.api.main import create_app
 def _make_test_app():
     from zebrafish_toxicology_atlas_schema.datamodel.sqla import Base  # type: ignore
 
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     Base.metadata.create_all(engine)
     SessionLocal = sessionmaker(bind=engine)
 

--- a/server/tests/test_api_studies.py
+++ b/server/tests/test_api_studies.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from server.api.deps import get_session
 from server.api.main import create_app
@@ -26,7 +27,11 @@ def _make_test_app():
     # Schema-provided SQLAlchemy base (assumed to exist)
     from zebrafish_toxicology_atlas_schema.datamodel.sqla import Base  # type: ignore
 
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     Base.metadata.create_all(engine)
     SessionLocal = sessionmaker(bind=engine)
 

--- a/server/tests/test_db.py
+++ b/server/tests/test_db.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine, inspect, text
 
-from db import init_db, get_session_factory
+from server.db import init_db, get_session_factory
 from zebrafish_toxicology_atlas_schema.datamodel.sqla import (
     ChemicalEntity,
     Experiment,

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -3,6 +3,15 @@ revision = 2
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -12,12 +21,34 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
@@ -39,6 +70,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
 ]
 
 [[package]]
@@ -99,6 +146,52 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
     { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -370,6 +463,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -391,6 +497,19 @@ wheels = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+]
+
+[[package]]
 name = "werkzeug"
 version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -407,8 +526,11 @@ name = "zapp-atlas-server"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "flask" },
+    { name = "httpx" },
     { name = "sqlalchemy" },
+    { name = "uvicorn" },
     { name = "zebrafish-toxicology-atlas-schema" },
 ]
 
@@ -419,9 +541,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.135.1" },
     { name = "flask", specifier = ">=3.1.2" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
-    { name = "zebrafish-toxicology-atlas-schema", git = "https://github.com/zappfish/zebrafish-toxicology-atlas-schema.git?rev=sqlalchemy-and-minor-tweaks" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
+    { name = "zebrafish-toxicology-atlas-schema", git = "https://github.com/zappfish/zebrafish-toxicology-atlas-schema.git?rev=pydantic-crud-models" },
 ]
 
 [package.metadata.requires-dev]
@@ -430,7 +555,7 @@ dev = [{ name = "pytest", specifier = ">=8.0" }]
 [[package]]
 name = "zebrafish-toxicology-atlas-schema"
 version = "0.1.0"
-source = { git = "https://github.com/zappfish/zebrafish-toxicology-atlas-schema.git?rev=sqlalchemy-and-minor-tweaks#d3180e1b6244db5aa22c2b8676f5960aad0d3b52" }
+source = { git = "https://github.com/zappfish/zebrafish-toxicology-atlas-schema.git?rev=pydantic-crud-models#06c47ea20c1d696fac243b91e64d23a4bf006b5c" }
 dependencies = [
     { name = "pydantic" },
     { name = "sqlalchemy" },


### PR DESCRIPTION
## Summary

- **Fly.io deployment (initial, untested):** Add `Dockerfile` (multi-stage Node frontend build + Python runtime), `fly.toml`, and `.dockerignore`
- **GCP Cloud Run (temporary dev):** Deployed to `https://zapp-atlas-1032453560151.us-central1.run.app` with GCS FUSE for SQLite persistence and GCS bucket for large data files. Justfile recipes: `gcp-build`, `gcp-deploy`, `gcp-ship`, `gcp-status`, `gcp-upload-data`
- **Fix `ModuleNotFoundError`:** Set `PYTHONPATH` in `Justfile` and `Dockerfile` so `server.*` imports resolve for uvicorn
- **Fix `/docs` OpenAPI schema crash:** Patch FastAPI's JSON schema generator to handle LinkML-generated bare `str` subclasses (`ExposureRouteEnum`, `ExposureTypeEnum`)
- **Dev ergonomics:** Add `Justfile` with dev/test/deploy recipes; add Vite dev proxy for API routes; configurable `VITE_DATA_BASE_URL` for data file source
- **Build fixes:** `skipLibCheck` and `module`/`types` tsconfig settings for Docker builds