### PR TITLE
Implement ORCID auth and consolidate application settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 tsconfig.tsbuildinfo
 __pycache__/
 .env.local
+server/.env
 
 # Server secrets and uploads
 server/credentials.txt

--- a/server/.env.default
+++ b/server/.env.default
@@ -1,0 +1,23 @@
+# Copy this file to server/.env for local development.
+# All settings use the ZAPP_ prefix because AppSettings sets env_prefix="ZAPP_".
+
+# SQLite database path.
+ZAPP_DB_PATH=src/zapp_atlas/db/data/zapp.db
+
+# Disable startup seeding when you want an empty or test-like local database.
+ZAPP_SKIP_SEED=false
+
+# Local image storage.
+ZAPP_UPLOAD_DIR=src/zapp_atlas/db/data/uploads
+ZAPP_MAX_UPLOAD_BYTES=52428800
+
+# S3-compatible image storage. Leave blank to use local image storage.
+ZAPP_AWS_ENDPOINT_URL_S3=
+ZAPP_BUCKET_NAME=
+ZAPP_BUCKET_PUBLIC_URL_PREFIX=
+
+# ORCID OAuth.
+ZAPP_ORCID_CLIENT_ID=
+ZAPP_ORCID_CLIENT_SECRET=
+ZAPP_ORCID_REDIRECT_URI=http://127.0.0.1:8000/registered
+ZAPP_ORCID_BASE_URL=https://orcid.org

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "boto3>=1.35",
     "fastapi>=0.135.1",
     "linkml",
+    "pydantic-settings>=2.14.0",
     "python-multipart>=0.0.9",
     "sqlalchemy>=2.0",
     "uvicorn>=0.30.0",

--- a/server/src/zapp_atlas/api/deps.py
+++ b/server/src/zapp_atlas/api/deps.py
@@ -4,22 +4,37 @@ from __future__ import annotations
 
 from collections.abc import Generator
 
+from fastapi import Request
 from sqlalchemy.orm import Session
 
 from zapp_atlas.db import get_engine, get_session_factory
+from zapp_atlas.settings import AppSettings, load_settings
 
 
-# In production we may want more explicit lifecycle management, but for now
-# having a module-level engine is fine.
-_engine = get_engine()
-_SessionLocal = get_session_factory(_engine)
+def _get_session_factory(request: Request):
+    session_factory = getattr(request.app.state, "session_factory", None)
+    if session_factory is None:
+        settings = get_app_settings(request)
+        engine = get_engine(settings=settings)
+        session_factory = get_session_factory(engine)
+        request.app.state.engine = engine
+        request.app.state.session_factory = session_factory
+    return session_factory
 
 
-def get_session() -> Generator[Session, None, None]:
+def get_session(request: Request) -> Generator[Session, None, None]:
     """Yield a SQLAlchemy session and ensure it is closed."""
 
-    session: Session = _SessionLocal()
+    session: Session = _get_session_factory(request)()
     try:
         yield session
     finally:
         session.close()
+
+
+def get_app_settings(request: Request) -> AppSettings:
+    settings = getattr(request.app.state, "settings", None)
+    if settings is None:
+        settings = load_settings()
+        request.app.state.settings = settings
+    return settings

--- a/server/src/zapp_atlas/api/routers/images.py
+++ b/server/src/zapp_atlas/api/routers/images.py
@@ -20,7 +20,7 @@ from fastapi import (
 from fastapi.responses import RedirectResponse, Response
 from sqlalchemy.orm import Session
 
-from zapp_atlas.api.deps import get_session
+from zapp_atlas.api.deps import get_app_settings, get_session
 from zapp_atlas.api.services.images import (
     ImageTooLargeError,
     UnsupportedImageTypeError,
@@ -31,6 +31,7 @@ from zapp_atlas.api.services.images import (
     load_image_bytes,
 )
 from zapp_atlas.db.image_storage import Storage, get_storage
+from zapp_atlas.settings import AppSettings
 
 from zapp_atlas.schema.pydantic_crud import ImageRead
 
@@ -38,11 +39,14 @@ from zapp_atlas.schema.pydantic_crud import ImageRead
 router = APIRouter(tags=["images"])
 
 
-def get_storage_dep() -> Storage:
-    return get_storage()
+def get_storage_dep(
+    settings: Annotated[AppSettings, Depends(get_app_settings)],
+) -> Storage:
+    return get_storage(settings)
 
 
 SessionDep = Annotated[Session, Depends(get_session)]
+SettingsDep = Annotated[AppSettings, Depends(get_app_settings)]
 StorageDep = Annotated[Storage, Depends(get_storage_dep)]
 
 
@@ -54,6 +58,7 @@ StorageDep = Annotated[Storage, Depends(get_storage_dep)]
 async def upload_image_endpoint(
     observation_id: int,
     session: SessionDep,
+    settings: SettingsDep,
     storage: StorageDep,
     file: Annotated[UploadFile, File()],
     magnification: Annotated[str | None, Form()] = None,
@@ -69,6 +74,7 @@ async def upload_image_endpoint(
             data=data,
             content_type=file.content_type or "application/octet-stream",
             storage=storage,
+            max_bytes=settings.max_upload_bytes,
             magnification=magnification,
             resolution=resolution,
             scale_bar=scale_bar,

--- a/server/src/zapp_atlas/api/services/images.py
+++ b/server/src/zapp_atlas/api/services/images.py
@@ -36,11 +36,12 @@ def create_image_for_observation(
     magnification: str | None = None,
     resolution: str | None = None,
     scale_bar: str | None = None,
+    max_bytes: int | None = None,
 ) -> Optional[Image]:
     if not content_type.startswith("image/"):
         raise UnsupportedImageTypeError(content_type)
 
-    limit = max_upload_bytes()
+    limit = max_bytes if max_bytes is not None else max_upload_bytes()
     if len(data) > limit:
         raise ImageTooLargeError(f"{len(data)} > {limit}")
 

--- a/server/src/zapp_atlas/auth/__init__.py
+++ b/server/src/zapp_atlas/auth/__init__.py
@@ -1,0 +1,2 @@
+"""ORCID OAuth support."""
+

--- a/server/src/zapp_atlas/auth/models.py
+++ b/server/src/zapp_atlas/auth/models.py
@@ -13,10 +13,10 @@ def _utcnow() -> datetime:
     return datetime.now(UTC)
 
 
-class OrcidAuthToken(Base):
+class OrcidIdentity(Base):
     """Stored ORCID identity for an authenticated researcher."""
 
-    __tablename__ = "OrcidAuthToken"
+    __tablename__ = "OrcidIdentity"
 
     id: Mapped[str] = mapped_column(
         Text(), primary_key=True, default=lambda: str(uuid.uuid4())

--- a/server/src/zapp_atlas/auth/models.py
+++ b/server/src/zapp_atlas/auth/models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, Integer, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from zapp_atlas.schema._gen.sqla import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class OrcidAuthToken(Base):
+    """Stored ORCID OAuth token for an authenticated researcher."""
+
+    __tablename__ = "OrcidAuthToken"
+
+    id: Mapped[str] = mapped_column(
+        Text(), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    orcid_id: Mapped[str] = mapped_column(Text(), index=True)
+    name: Mapped[str | None] = mapped_column(Text())
+    access_token: Mapped[str] = mapped_column(Text())
+    refresh_token: Mapped[str | None] = mapped_column(Text())
+    token_type: Mapped[str | None] = mapped_column(Text())
+    scope: Mapped[str | None] = mapped_column(Text())
+    expires_in: Mapped[int | None] = mapped_column(Integer())
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
+

--- a/server/src/zapp_atlas/auth/models.py
+++ b/server/src/zapp_atlas/auth/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, Integer, Text
+from sqlalchemy import DateTime, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from zapp_atlas.schema._gen.sqla import Base
@@ -14,23 +14,16 @@ def _utcnow() -> datetime:
 
 
 class OrcidAuthToken(Base):
-    """Stored ORCID OAuth token for an authenticated researcher."""
+    """Stored ORCID identity for an authenticated researcher."""
 
     __tablename__ = "OrcidAuthToken"
 
     id: Mapped[str] = mapped_column(
         Text(), primary_key=True, default=lambda: str(uuid.uuid4())
     )
-    orcid_id: Mapped[str] = mapped_column(Text(), index=True)
+    orcid_id: Mapped[str] = mapped_column(Text(), unique=True, index=True)
     name: Mapped[str | None] = mapped_column(Text())
-    access_token: Mapped[str] = mapped_column(Text())
-    refresh_token: Mapped[str | None] = mapped_column(Text())
-    token_type: Mapped[str | None] = mapped_column(Text())
-    scope: Mapped[str | None] = mapped_column(Text())
-    expires_in: Mapped[int | None] = mapped_column(Integer())
-    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
     )
-

--- a/server/src/zapp_atlas/auth/router.py
+++ b/server/src/zapp_atlas/auth/router.py
@@ -15,10 +15,10 @@ from zapp_atlas.auth.services import (
     build_authorization_url,
     exchange_code_for_token,
     get_orcid_config,
-    get_orcid_token,
+    get_orcid_identity,
     make_state,
     state_matches,
-    store_orcid_token,
+    store_orcid_identity,
 )
 from zapp_atlas.settings import AppSettings
 from zapp_atlas.html.router import _escape
@@ -89,14 +89,14 @@ def registered_orcid_callback(
     try:
         config = get_orcid_config(settings)
         token_payload = exchange_code_for_token(config, code)
-        token = store_orcid_token(session, token_payload)
+        identity = store_orcid_identity(session, token_payload)
     except (OrcidConfigError, OrcidTokenExchangeError) as exc:
         return _error_page(str(exc), status.HTTP_502_BAD_GATEWAY)
 
     response = RedirectResponse("/login", status_code=status.HTTP_303_SEE_OTHER)
     response.set_cookie(
         ORCID_AUTH_COOKIE,
-        token.id,
+        identity.id,
         httponly=True,
         secure=config.redirect_uri.startswith("https://"),
         samesite="lax",
@@ -115,19 +115,19 @@ def logout_orcid() -> RedirectResponse:
 @router.get("/auth/orcid/status", response_class=HTMLResponse)
 def orcid_status(
     session: Annotated[Session, Depends(get_session)],
-    auth_id: Annotated[str | None, Cookie(alias=ORCID_AUTH_COOKIE)] = None,
+    identity_id: Annotated[str | None, Cookie(alias=ORCID_AUTH_COOKIE)] = None,
 ) -> HTMLResponse:
-    if auth_id is None:
+    if identity_id is None:
         return HTMLResponse("")
 
-    token = get_orcid_token(session, auth_id)
-    if token is None:
+    identity = get_orcid_identity(session, identity_id)
+    if identity is None:
         return HTMLResponse(
             "<p>No ORCID login was found for this browser.</p>",
             status_code=status.HTTP_404_NOT_FOUND,
         )
-    display_name = _escape(token.name) or "ORCID user"
-    orcid_id = _escape(token.orcid_id)
+    display_name = _escape(identity.name) or "ORCID user"
+    orcid_id = _escape(identity.orcid_id)
     return HTMLResponse(
         f"<p><strong>Signed in as {display_name}</strong><br>ORCID iD {orcid_id}</p>"
     )

--- a/server/src/zapp_atlas/auth/router.py
+++ b/server/src/zapp_atlas/auth/router.py
@@ -20,21 +20,10 @@ from zapp_atlas.auth.services import (
     store_orcid_token,
 )
 from zapp_atlas.settings import AppSettings
+from zapp_atlas.html.router import _escape
 
 
 router = APIRouter(tags=["auth"])
-
-
-def _escape(value: str | None) -> str:
-    if not value:
-        return ""
-    return (
-        value.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
-        .replace("'", "&#x27;")
-    )
 
 
 def _error_page(message: str, status_code: int = status.HTTP_400_BAD_REQUEST) -> HTMLResponse:

--- a/server/src/zapp_atlas/auth/router.py
+++ b/server/src/zapp_atlas/auth/router.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
 
-from zapp_atlas.api.deps import get_session
+from zapp_atlas.api.deps import get_app_settings, get_session
 from zapp_atlas.auth.services import (
     ORCID_STATE_COOKIE,
     OrcidConfigError,
@@ -19,6 +19,7 @@ from zapp_atlas.auth.services import (
     state_matches,
     store_orcid_token,
 )
+from zapp_atlas.settings import AppSettings
 
 
 router = APIRouter(tags=["auth"])
@@ -54,9 +55,11 @@ def _error_page(message: str, status_code: int = status.HTTP_400_BAD_REQUEST) ->
 
 
 @router.get("/auth/orcid/login")
-def login_with_orcid() -> RedirectResponse:
+def login_with_orcid(
+    settings: Annotated[AppSettings, Depends(get_app_settings)],
+) -> RedirectResponse:
     try:
-        config = get_orcid_config()
+        config = get_orcid_config(settings)
     except OrcidConfigError as exc:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -79,6 +82,7 @@ def login_with_orcid() -> RedirectResponse:
 @router.get("/registered", response_class=HTMLResponse)
 def registered_orcid_callback(
     session: Annotated[Session, Depends(get_session)],
+    settings: Annotated[AppSettings, Depends(get_app_settings)],
     code: Annotated[str | None, Query()] = None,
     state: Annotated[str | None, Query()] = None,
     error: Annotated[str | None, Query()] = None,
@@ -93,7 +97,7 @@ def registered_orcid_callback(
         return _error_page("ORCID login state did not match. Please try again.")
 
     try:
-        config = get_orcid_config()
+        config = get_orcid_config(settings)
         token_payload = exchange_code_for_token(config, code)
         token = store_orcid_token(session, token_payload)
     except (OrcidConfigError, OrcidTokenExchangeError) as exc:
@@ -122,4 +126,3 @@ def orcid_status(
     return HTMLResponse(
         f"<p><strong>Signed in as {display_name}</strong><br>ORCID iD {orcid_id}</p>"
     )
-

--- a/server/src/zapp_atlas/auth/router.py
+++ b/server/src/zapp_atlas/auth/router.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Query, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy.orm import Session
+
+from zapp_atlas.api.deps import get_session
+from zapp_atlas.auth.services import (
+    ORCID_STATE_COOKIE,
+    OrcidConfigError,
+    OrcidTokenExchangeError,
+    build_authorization_url,
+    exchange_code_for_token,
+    get_orcid_config,
+    get_orcid_token,
+    make_state,
+    state_matches,
+    store_orcid_token,
+)
+
+
+router = APIRouter(tags=["auth"])
+
+
+def _escape(value: str | None) -> str:
+    if not value:
+        return ""
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#x27;")
+    )
+
+
+def _error_page(message: str, status_code: int = status.HTTP_400_BAD_REQUEST) -> HTMLResponse:
+    return HTMLResponse(
+        f"""<!doctype html>
+<html lang="en">
+  <head><title>ORCID Login Error</title></head>
+  <body>
+    <main>
+      <h1>ORCID login failed</h1>
+      <p>{_escape(message)}</p>
+      <p><a href="/login">Return to login</a></p>
+    </main>
+  </body>
+</html>""",
+        status_code=status_code,
+    )
+
+
+@router.get("/auth/orcid/login")
+def login_with_orcid() -> RedirectResponse:
+    try:
+        config = get_orcid_config()
+    except OrcidConfigError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(exc),
+        ) from exc
+
+    state = make_state()
+    response = RedirectResponse(build_authorization_url(config, state))
+    response.set_cookie(
+        ORCID_STATE_COOKIE,
+        state,
+        max_age=600,
+        httponly=True,
+        secure=config.redirect_uri.startswith("https://"),
+        samesite="lax",
+    )
+    return response
+
+
+@router.get("/registered", response_class=HTMLResponse)
+def registered_orcid_callback(
+    session: Annotated[Session, Depends(get_session)],
+    code: Annotated[str | None, Query()] = None,
+    state: Annotated[str | None, Query()] = None,
+    error: Annotated[str | None, Query()] = None,
+    error_description: Annotated[str | None, Query()] = None,
+    expected_state: Annotated[str | None, Cookie(alias=ORCID_STATE_COOKIE)] = None,
+):
+    if error:
+        return _error_page(error_description or error)
+    if not code:
+        return _error_page("ORCID did not return an authorization code.")
+    if not state or not expected_state or not state_matches(state, expected_state):
+        return _error_page("ORCID login state did not match. Please try again.")
+
+    try:
+        config = get_orcid_config()
+        token_payload = exchange_code_for_token(config, code)
+        token = store_orcid_token(session, token_payload)
+    except (OrcidConfigError, OrcidTokenExchangeError) as exc:
+        return _error_page(str(exc), status.HTTP_502_BAD_GATEWAY)
+
+    response = RedirectResponse(
+        f"/login?auth_id={token.id}", status_code=status.HTTP_303_SEE_OTHER
+    )
+    response.delete_cookie(ORCID_STATE_COOKIE)
+    return response
+
+
+@router.get("/auth/orcid/status/{auth_id}", response_class=HTMLResponse)
+def orcid_status(
+    auth_id: str,
+    session: Annotated[Session, Depends(get_session)],
+) -> HTMLResponse:
+    token = get_orcid_token(session, auth_id)
+    if token is None:
+        return HTMLResponse(
+            "<p>No ORCID login was found for this callback.</p>",
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
+    display_name = _escape(token.name) or "ORCID user"
+    orcid_id = _escape(token.orcid_id)
+    return HTMLResponse(
+        f"<p><strong>Signed in as {display_name}</strong><br>ORCID iD {orcid_id}</p>"
+    )
+

--- a/server/src/zapp_atlas/auth/router.py
+++ b/server/src/zapp_atlas/auth/router.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from zapp_atlas.api.deps import get_app_settings, get_session
 from zapp_atlas.auth.services import (
+    ORCID_AUTH_COOKIE,
     ORCID_STATE_COOKIE,
     OrcidConfigError,
     OrcidTokenExchangeError,
@@ -92,22 +93,37 @@ def registered_orcid_callback(
     except (OrcidConfigError, OrcidTokenExchangeError) as exc:
         return _error_page(str(exc), status.HTTP_502_BAD_GATEWAY)
 
-    response = RedirectResponse(
-        f"/login?auth_id={token.id}", status_code=status.HTTP_303_SEE_OTHER
+    response = RedirectResponse("/login", status_code=status.HTTP_303_SEE_OTHER)
+    response.set_cookie(
+        ORCID_AUTH_COOKIE,
+        token.id,
+        httponly=True,
+        secure=config.redirect_uri.startswith("https://"),
+        samesite="lax",
     )
     response.delete_cookie(ORCID_STATE_COOKIE)
     return response
 
 
-@router.get("/auth/orcid/status/{auth_id}", response_class=HTMLResponse)
+@router.post("/auth/orcid/logout")
+def logout_orcid() -> RedirectResponse:
+    response = RedirectResponse("/login", status_code=status.HTTP_303_SEE_OTHER)
+    response.delete_cookie(ORCID_AUTH_COOKIE)
+    return response
+
+
+@router.get("/auth/orcid/status", response_class=HTMLResponse)
 def orcid_status(
-    auth_id: str,
     session: Annotated[Session, Depends(get_session)],
+    auth_id: Annotated[str | None, Cookie(alias=ORCID_AUTH_COOKIE)] = None,
 ) -> HTMLResponse:
+    if auth_id is None:
+        return HTMLResponse("")
+
     token = get_orcid_token(session, auth_id)
     if token is None:
         return HTMLResponse(
-            "<p>No ORCID login was found for this callback.</p>",
+            "<p>No ORCID login was found for this browser.</p>",
             status_code=status.HTTP_404_NOT_FOUND,
         )
     display_name = _escape(token.name) or "ORCID user"

--- a/server/src/zapp_atlas/auth/services.py
+++ b/server/src/zapp_atlas/auth/services.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from sqlalchemy.orm import Session
+
+from zapp_atlas.auth.models import OrcidAuthToken
+
+
+ORCID_STATE_COOKIE = "zapp_orcid_state"
+DEFAULT_ORCID_BASE_URL = "https://orcid.org"
+DEFAULT_ORCID_REDIRECT_URI = "http://127.0.0.1:8000/registered"
+
+
+class OrcidConfigError(RuntimeError):
+    pass
+
+
+class OrcidTokenExchangeError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class OrcidConfig:
+    client_id: str
+    client_secret: str
+    redirect_uri: str
+    base_url: str = DEFAULT_ORCID_BASE_URL
+
+    @property
+    def authorize_url(self) -> str:
+        return f"{self.base_url.rstrip('/')}/oauth/authorize"
+
+    @property
+    def token_url(self) -> str:
+        return f"{self.base_url.rstrip('/')}/oauth/token"
+
+
+def get_orcid_config() -> OrcidConfig:
+    client_id = os.getenv("ORCID_CLIENT_ID", "").strip()
+    client_secret = os.getenv("ORCID_CLIENT_SECRET", "").strip()
+    if not client_id or not client_secret:
+        raise OrcidConfigError("ORCID_CLIENT_ID and ORCID_CLIENT_SECRET must be set")
+    return OrcidConfig(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=os.getenv("ORCID_REDIRECT_URI", DEFAULT_ORCID_REDIRECT_URI).strip(),
+        base_url=os.getenv("ORCID_BASE_URL", DEFAULT_ORCID_BASE_URL).strip(),
+    )
+
+
+def make_state() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def state_matches(left: str, right: str) -> bool:
+    return secrets.compare_digest(left, right)
+
+
+def build_authorization_url(config: OrcidConfig, state: str) -> str:
+    query = urlencode(
+        {
+            "client_id": config.client_id,
+            "response_type": "code",
+            "scope": "/authenticate",
+            "redirect_uri": config.redirect_uri,
+            "state": state,
+        }
+    )
+    return f"{config.authorize_url}?{query}"
+
+
+def exchange_code_for_token(config: OrcidConfig, code: str) -> dict[str, Any]:
+    form = urlencode(
+        {
+            "client_id": config.client_id,
+            "client_secret": config.client_secret,
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": config.redirect_uri,
+        }
+    ).encode("utf-8")
+    request = Request(
+        config.token_url,
+        data=form,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=15) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise OrcidTokenExchangeError(
+            f"ORCID token endpoint returned {exc.code}: {detail}"
+        ) from exc
+    except (OSError, URLError, json.JSONDecodeError) as exc:
+        raise OrcidTokenExchangeError("Could not exchange ORCID authorization code") from exc
+
+
+def store_orcid_token(session: Session, payload: dict[str, Any]) -> OrcidAuthToken:
+    orcid_id = payload.get("orcid")
+    access_token = payload.get("access_token")
+    if not orcid_id or not access_token:
+        raise OrcidTokenExchangeError("ORCID token response was missing identity or token")
+
+    expires_in = payload.get("expires_in")
+    expires_at = None
+    if isinstance(expires_in, int):
+        expires_at = datetime.now(UTC) + timedelta(seconds=expires_in)
+
+    row = OrcidAuthToken(
+        orcid_id=orcid_id,
+        name=payload.get("name"),
+        access_token=access_token,
+        refresh_token=payload.get("refresh_token"),
+        token_type=payload.get("token_type"),
+        scope=payload.get("scope"),
+        expires_in=expires_in if isinstance(expires_in, int) else None,
+        expires_at=expires_at,
+    )
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    return row
+
+
+def get_orcid_token(session: Session, auth_id: str) -> OrcidAuthToken | None:
+    return session.get(OrcidAuthToken, auth_id)
+

--- a/server/src/zapp_atlas/auth/services.py
+++ b/server/src/zapp_atlas/auth/services.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import json
 import secrets
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from zapp_atlas.auth.models import OrcidAuthToken
@@ -112,26 +112,20 @@ def exchange_code_for_token(config: OrcidConfig, code: str) -> dict[str, Any]:
 
 def store_orcid_token(session: Session, payload: dict[str, Any]) -> OrcidAuthToken:
     orcid_id = payload.get("orcid")
-    access_token = payload.get("access_token")
-    if not orcid_id or not access_token:
-        raise OrcidTokenExchangeError("ORCID token response was missing identity or token")
+    if not orcid_id:
+        raise OrcidTokenExchangeError("ORCID token response was missing identity")
 
-    expires_in = payload.get("expires_in")
-    expires_at = None
-    if isinstance(expires_in, int):
-        expires_at = datetime.now(UTC) + timedelta(seconds=expires_in)
-
-    row = OrcidAuthToken(
-        orcid_id=orcid_id,
-        name=payload.get("name"),
-        access_token=access_token,
-        refresh_token=payload.get("refresh_token"),
-        token_type=payload.get("token_type"),
-        scope=payload.get("scope"),
-        expires_in=expires_in if isinstance(expires_in, int) else None,
-        expires_at=expires_at,
+    row = session.scalar(
+        select(OrcidAuthToken)
+        .where(OrcidAuthToken.orcid_id == orcid_id)
+        .order_by(OrcidAuthToken.created_at)
     )
-    session.add(row)
+    if row is None:
+        row = OrcidAuthToken(orcid_id=orcid_id)
+        session.add(row)
+
+    row.name = payload.get("name")
+
     session.commit()
     session.refresh(row)
     return row

--- a/server/src/zapp_atlas/auth/services.py
+++ b/server/src/zapp_atlas/auth/services.py
@@ -11,7 +11,7 @@ from urllib.request import Request, urlopen
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from zapp_atlas.auth.models import OrcidAuthToken
+from zapp_atlas.auth.models import OrcidIdentity
 from zapp_atlas.settings import AppSettings, load_settings
 
 
@@ -111,26 +111,26 @@ def exchange_code_for_token(config: OrcidConfig, code: str) -> dict[str, Any]:
         raise OrcidTokenExchangeError("Could not exchange ORCID authorization code") from exc
 
 
-def store_orcid_token(session: Session, payload: dict[str, Any]) -> OrcidAuthToken:
+def store_orcid_identity(session: Session, payload: dict[str, Any]) -> OrcidIdentity:
     orcid_id = payload.get("orcid")
     if not orcid_id:
         raise OrcidTokenExchangeError("ORCID token response was missing identity")
 
-    row = session.scalar(
-        select(OrcidAuthToken)
-        .where(OrcidAuthToken.orcid_id == orcid_id)
-        .order_by(OrcidAuthToken.created_at)
+    identity = session.scalar(
+        select(OrcidIdentity)
+        .where(OrcidIdentity.orcid_id == orcid_id)
+        .order_by(OrcidIdentity.created_at)
     )
-    if row is None:
-        row = OrcidAuthToken(orcid_id=orcid_id)
-        session.add(row)
+    if identity is None:
+        identity = OrcidIdentity(orcid_id=orcid_id)
+        session.add(identity)
 
-    row.name = payload.get("name")
+    identity.name = payload.get("name")
 
     session.commit()
-    session.refresh(row)
-    return row
+    session.refresh(identity)
+    return identity
 
 
-def get_orcid_token(session: Session, auth_id: str) -> OrcidAuthToken | None:
-    return session.get(OrcidAuthToken, auth_id)
+def get_orcid_identity(session: Session, auth_id: str) -> OrcidIdentity | None:
+    return session.get(OrcidIdentity, auth_id)

--- a/server/src/zapp_atlas/auth/services.py
+++ b/server/src/zapp_atlas/auth/services.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -13,11 +12,10 @@ from urllib.request import Request, urlopen
 from sqlalchemy.orm import Session
 
 from zapp_atlas.auth.models import OrcidAuthToken
+from zapp_atlas.settings import AppSettings, load_settings
 
 
 ORCID_STATE_COOKIE = "zapp_orcid_state"
-DEFAULT_ORCID_BASE_URL = "https://orcid.org"
-DEFAULT_ORCID_REDIRECT_URI = "http://127.0.0.1:8000/registered"
 
 
 class OrcidConfigError(RuntimeError):
@@ -33,7 +31,7 @@ class OrcidConfig:
     client_id: str
     client_secret: str
     redirect_uri: str
-    base_url: str = DEFAULT_ORCID_BASE_URL
+    base_url: str
 
     @property
     def authorize_url(self) -> str:
@@ -44,16 +42,19 @@ class OrcidConfig:
         return f"{self.base_url.rstrip('/')}/oauth/token"
 
 
-def get_orcid_config() -> OrcidConfig:
-    client_id = os.getenv("ORCID_CLIENT_ID", "").strip()
-    client_secret = os.getenv("ORCID_CLIENT_SECRET", "").strip()
+def get_orcid_config(settings: AppSettings | None = None) -> OrcidConfig:
+    settings = settings or load_settings()
+    client_id = settings.orcid_client_id
+    client_secret = settings.orcid_client_secret
     if not client_id or not client_secret:
-        raise OrcidConfigError("ORCID_CLIENT_ID and ORCID_CLIENT_SECRET must be set")
+        raise OrcidConfigError(
+            "ZAPP_ORCID_CLIENT_ID and ZAPP_ORCID_CLIENT_SECRET must be set"
+        )
     return OrcidConfig(
         client_id=client_id,
         client_secret=client_secret,
-        redirect_uri=os.getenv("ORCID_REDIRECT_URI", DEFAULT_ORCID_REDIRECT_URI).strip(),
-        base_url=os.getenv("ORCID_BASE_URL", DEFAULT_ORCID_BASE_URL).strip(),
+        redirect_uri=settings.orcid_redirect_uri,
+        base_url=settings.orcid_base_url,
     )
 
 
@@ -138,4 +139,3 @@ def store_orcid_token(session: Session, payload: dict[str, Any]) -> OrcidAuthTok
 
 def get_orcid_token(session: Session, auth_id: str) -> OrcidAuthToken | None:
     return session.get(OrcidAuthToken, auth_id)
-

--- a/server/src/zapp_atlas/auth/services.py
+++ b/server/src/zapp_atlas/auth/services.py
@@ -16,6 +16,7 @@ from zapp_atlas.settings import AppSettings, load_settings
 
 
 ORCID_STATE_COOKIE = "zapp_orcid_state"
+ORCID_AUTH_COOKIE = "zapp_orcid_auth"
 
 
 class OrcidConfigError(RuntimeError):

--- a/server/src/zapp_atlas/db/db.py
+++ b/server/src/zapp_atlas/db/db.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from zapp_atlas.schema.sqla import Base
+import zapp_atlas.auth.models  # noqa: F401
 
 SERVER_DIR = Path(__file__).resolve().parent
 DEFAULT_DB_PATH = SERVER_DIR / "data" / "zapp.db"

--- a/server/src/zapp_atlas/db/db.py
+++ b/server/src/zapp_atlas/db/db.py
@@ -1,21 +1,19 @@
-import os
 from pathlib import Path
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
+from zapp_atlas.settings import AppSettings, DEFAULT_DB_PATH, load_settings
 from zapp_atlas.schema.sqla import Base
 import zapp_atlas.auth.models  # noqa: F401
 
-SERVER_DIR = Path(__file__).resolve().parent
-DEFAULT_DB_PATH = SERVER_DIR / "data" / "zapp.db"
+
+def get_db_path(settings: AppSettings | None = None) -> Path:
+    return (settings or load_settings()).db_path
 
 
-def get_db_path() -> Path:
-    env = os.getenv("ZAPP_DB_PATH")
-    return Path(env).resolve() if env else DEFAULT_DB_PATH
-
-
-def get_engine(db_path: Path | None = None):
-    path = db_path or get_db_path()
+def get_engine(db_path: Path | None = None, settings: AppSettings | None = None):
+    path = db_path or get_db_path(settings)
     path.parent.mkdir(parents=True, exist_ok=True)
     return create_engine(f"sqlite:///{path}", echo=False)
 

--- a/server/src/zapp_atlas/db/image_storage.py
+++ b/server/src/zapp_atlas/db/image_storage.py
@@ -5,10 +5,8 @@ Two backends:
 * ``LocalFilesystemStorage`` — writes blobs under a local directory.
   Used when no S3-compatible bucket endpoint is configured.
 * ``BucketStorage`` — any S3-compatible object store (Tigris, Cloudflare
-  R2, MinIO, Backblaze B2, ...). Activated when ``AWS_ENDPOINT_URL_S3``
-  and ``BUCKET_NAME`` are both set. Env var names follow the boto3 /
-  AWS SDK convention so they match what ``fly storage create`` and most
-  provider docs emit.
+  R2, MinIO, Backblaze B2, ...). Activated when ``ZAPP_AWS_ENDPOINT_URL_S3``
+  and ``ZAPP_BUCKET_NAME`` are both set.
 
 Callers get a ``Storage`` instance from ``get_storage()``; backends are
 swapped without the caller noticing.
@@ -16,10 +14,11 @@ swapped without the caller noticing.
 
 from __future__ import annotations
 
-import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
+
+from zapp_atlas.settings import AppSettings, load_settings
 
 
 @dataclass
@@ -128,25 +127,22 @@ class BucketStorage(Storage):
         )
 
 
-def _default_local_dir() -> Path:
-    env = os.getenv("ZAPP_UPLOAD_DIR")
-    if env:
-        return Path(env)
-    return Path(__file__).resolve().parent / "data" / "uploads"
+def _default_local_dir(settings: AppSettings | None = None) -> Path:
+    return (settings or load_settings()).upload_dir
 
 
-def get_storage() -> Storage:
-    endpoint = os.getenv("AWS_ENDPOINT_URL_S3")
-    bucket = os.getenv("BUCKET_NAME")
+def get_storage(settings: AppSettings | None = None) -> Storage:
+    settings = settings or load_settings()
+    endpoint = settings.aws_endpoint_url_s3
+    bucket = settings.bucket_name
     if endpoint and bucket:
         return BucketStorage(
             endpoint_url=endpoint,
             bucket=bucket,
-            public_url_prefix=os.getenv("ZAPP_BUCKET_PUBLIC_URL_PREFIX"),
+            public_url_prefix=settings.bucket_public_url_prefix,
         )
-    return LocalFilesystemStorage(root=_default_local_dir())
+    return LocalFilesystemStorage(root=_default_local_dir(settings))
 
 
-def max_upload_bytes() -> int:
-    raw = os.getenv("ZAPP_MAX_UPLOAD_BYTES")
-    return int(raw) if raw else 50 * 1024 * 1024
+def max_upload_bytes(settings: AppSettings | None = None) -> int:
+    return (settings or load_settings()).max_upload_bytes

--- a/server/src/zapp_atlas/html/__init__.py
+++ b/server/src/zapp_atlas/html/__init__.py
@@ -1,0 +1,2 @@
+"""HTML pages for small server-rendered tools."""
+

--- a/server/src/zapp_atlas/html/router.py
+++ b/server/src/zapp_atlas/html/router.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter
 from fastapi.responses import HTMLResponse
 
 
@@ -20,15 +20,7 @@ def _escape(value: str | None) -> str:
 
 
 @router.get("/login", response_class=HTMLResponse)
-def login_page(auth_id: str | None = Query(default=None)) -> HTMLResponse:
-    status_attrs = ""
-    if auth_id:
-        status_attrs = (
-            f' hx-get="/auth/orcid/status/{_escape(auth_id)}"'
-            ' hx-trigger="load"'
-            ' hx-swap="innerHTML"'
-        )
-
+def login_page() -> HTMLResponse:
     return HTMLResponse(
         f"""<!doctype html>
 <html lang="en">
@@ -43,9 +35,11 @@ def login_page(auth_id: str | None = Query(default=None)) -> HTMLResponse:
       <h1>ZAPP Atlas ORCID Login</h1>
       <p>Use ORCID to confirm an authenticated researcher identity for this server.</p>
       <p><a href="/auth/orcid/login">Sign in with ORCID</a></p>
-      <section id="orcid-status"{status_attrs}></section>
+      <form method="post" action="/auth/orcid/logout">
+        <button type="submit">Log out</button>
+      </form>
+      <section id="orcid-status" hx-get="/auth/orcid/status" hx-trigger="load" hx-swap="innerHTML"></section>
     </main>
   </body>
 </html>"""
     )
-

--- a/server/src/zapp_atlas/html/router.py
+++ b/server/src/zapp_atlas/html/router.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+from fastapi.responses import HTMLResponse
+
+
+router = APIRouter(tags=["html"])
+
+
+def _escape(value: str | None) -> str:
+    if not value:
+        return ""
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#x27;")
+    )
+
+
+@router.get("/login", response_class=HTMLResponse)
+def login_page(auth_id: str | None = Query(default=None)) -> HTMLResponse:
+    status_attrs = ""
+    if auth_id:
+        status_attrs = (
+            f' hx-get="/auth/orcid/status/{_escape(auth_id)}"'
+            ' hx-trigger="load"'
+            ' hx-swap="innerHTML"'
+        )
+
+    return HTMLResponse(
+        f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>ZAPP Atlas ORCID Login</title>
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+  </head>
+  <body>
+    <main>
+      <h1>ZAPP Atlas ORCID Login</h1>
+      <p>Use ORCID to confirm an authenticated researcher identity for this server.</p>
+      <p><a href="/auth/orcid/login">Sign in with ORCID</a></p>
+      <section id="orcid-status"{status_attrs}></section>
+    </main>
+  </body>
+</html>"""
+    )
+

--- a/server/src/zapp_atlas/main.py
+++ b/server/src/zapp_atlas/main.py
@@ -6,7 +6,6 @@ Notes
 * The LinkML-generated models are imported from the schema package.
 """
 
-import os
 from contextlib import asynccontextmanager
 
 from fastapi import APIRouter, FastAPI
@@ -20,25 +19,30 @@ from zapp_atlas.api.routers.studies import router as studies_router
 from zapp_atlas.db import get_engine, get_session_factory, init_db
 from zapp_atlas.html.router import router as html_router
 from zapp_atlas.seed import seed
+from zapp_atlas.settings import AppSettings, load_settings
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    engine = get_engine()
+    settings = app.state.settings
+    engine = get_engine(settings=settings)
+    app.state.engine = engine
+    app.state.session_factory = get_session_factory(engine)
     init_db(engine)
-    if os.getenv("ZAPP_SKIP_SEED", "").lower() not in {"1", "true", "yes"}:
-        Session = get_session_factory(engine)
+    if not settings.skip_seed:
+        Session = app.state.session_factory
         with Session() as session:
             seed(session)
     yield
 
 
-def create_app() -> FastAPI:
+def create_app(settings: AppSettings | None = None) -> FastAPI:
     app = FastAPI(
         title="ZAPP Atlas API",
         version="0.1.0",
         lifespan=lifespan,
     )
+    app.state.settings = settings or load_settings()
 
     @app.get("/health")
     def health() -> dict[str, str]:

--- a/server/src/zapp_atlas/main.py
+++ b/server/src/zapp_atlas/main.py
@@ -11,12 +11,14 @@ from contextlib import asynccontextmanager
 
 from fastapi import APIRouter, FastAPI
 
+from zapp_atlas.auth.router import router as auth_router
 from zapp_atlas.api.routers.experiments import router as experiments_router
 from zapp_atlas.api.routers.exposures import router as exposures_router
 from zapp_atlas.api.routers.images import router as images_router
 from zapp_atlas.api.routers.observations import router as observations_router
 from zapp_atlas.api.routers.studies import router as studies_router
 from zapp_atlas.db import get_engine, get_session_factory, init_db
+from zapp_atlas.html.router import router as html_router
 from zapp_atlas.seed import seed
 
 
@@ -41,6 +43,9 @@ def create_app() -> FastAPI:
     @app.get("/health")
     def health() -> dict[str, str]:
         return {"status": "ok"}
+
+    app.include_router(html_router)
+    app.include_router(auth_router)
 
     api = APIRouter(prefix="/api")
     api.include_router(studies_router)

--- a/server/src/zapp_atlas/settings.py
+++ b/server/src/zapp_atlas/settings.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+DEFAULT_DATA_DIR = PACKAGE_DIR / "db" / "data"
+DEFAULT_DB_PATH = DEFAULT_DATA_DIR / "zapp.db"
+DEFAULT_UPLOAD_DIR = DEFAULT_DATA_DIR / "uploads"
+DEFAULT_MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+DEFAULT_ORCID_BASE_URL = "https://orcid.org"
+DEFAULT_ORCID_REDIRECT_URI = "http://127.0.0.1:8000/registered"
+
+
+class AppSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_prefix="ZAPP_",
+        env_ignore_empty=True,
+        extra="ignore",
+        str_strip_whitespace=True,
+    )
+
+    db_path: Path = DEFAULT_DB_PATH
+    upload_dir: Path = DEFAULT_UPLOAD_DIR
+    max_upload_bytes: int = DEFAULT_MAX_UPLOAD_BYTES
+    skip_seed: bool = False
+
+    aws_endpoint_url_s3: str | None = None
+    bucket_name: str | None = None
+    bucket_public_url_prefix: str | None = None
+
+    orcid_client_id: str = ""
+    orcid_client_secret: str = ""
+    orcid_redirect_uri: str = DEFAULT_ORCID_REDIRECT_URI
+    orcid_base_url: str = DEFAULT_ORCID_BASE_URL
+
+
+def load_settings(**overrides) -> AppSettings:
+    return AppSettings(**overrides)

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -12,7 +12,7 @@ from zapp_atlas.main import create_app
 
 @pytest.fixture
 def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
-    from zapp_atlas.schema.sqla import Base  # type: ignore
+    from zapp_atlas.db import init_db
 
     # Lifespan tries to seed into a real on-disk DB; disable for tests.
     monkeypatch.setenv("ZAPP_SKIP_SEED", "1")
@@ -22,7 +22,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    Base.metadata.create_all(engine)
+    init_db(engine)
     SessionLocal = sessionmaker(bind=engine)
 
     app = create_app()

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -8,14 +8,12 @@ from sqlalchemy.pool import StaticPool
 
 from zapp_atlas.api.deps import get_session
 from zapp_atlas.main import create_app
+from zapp_atlas.settings import AppSettings
 
 
 @pytest.fixture
-def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def client(tmp_path) -> TestClient:
     from zapp_atlas.db import init_db
-
-    # Lifespan tries to seed into a real on-disk DB; disable for tests.
-    monkeypatch.setenv("ZAPP_SKIP_SEED", "1")
 
     engine = create_engine(
         "sqlite:///:memory:",
@@ -25,7 +23,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     init_db(engine)
     SessionLocal = sessionmaker(bind=engine)
 
-    app = create_app()
+    app = create_app(AppSettings(skip_seed=True, upload_dir=tmp_path))
 
     def _override_get_session():
         session = SessionLocal()

--- a/server/tests/test_api_deletes.py
+++ b/server/tests/test_api_deletes.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 from fastapi.testclient import TestClient
 
 
@@ -13,13 +12,6 @@ _PNG_1X1_RED = bytes.fromhex(
     "00907753DE0000000C4944415408D76368F8FF1F0000040100017F3F"
     "8F180000000049454E44AE426082"
 )
-
-
-@pytest.fixture(autouse=True)
-def _tmp_upload_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("ZAPP_UPLOAD_DIR", str(tmp_path))
-    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
-    return tmp_path
 
 
 def _build_study_graph(client: TestClient) -> dict:

--- a/server/tests/test_api_images.py
+++ b/server/tests/test_api_images.py
@@ -6,9 +6,6 @@ Local-filesystem backend only; S3/Tigris path is env-gated and not
 exercised here.
 """
 
-from pathlib import Path
-
-import pytest
 from fastapi.testclient import TestClient
 
 
@@ -18,14 +15,6 @@ _PNG_1X1_RED = bytes.fromhex(
     "00907753DE0000000C4944415408D76368F8FF1F0000040100017F3F"
     "8F180000000049454E44AE426082"
 )
-
-
-@pytest.fixture(autouse=True)
-def _tmp_upload_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Point the local storage backend at a per-test tmp dir."""
-    monkeypatch.setenv("ZAPP_UPLOAD_DIR", str(tmp_path))
-    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
-    return tmp_path
 
 
 def _create_observation(client: TestClient) -> int:
@@ -98,10 +87,8 @@ def test_upload_rejects_non_image_content_type(client: TestClient) -> None:
     assert res.status_code == 415
 
 
-def test_upload_rejects_oversized(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("ZAPP_MAX_UPLOAD_BYTES", "64")
+def test_upload_rejects_oversized(client: TestClient) -> None:
+    client.app.state.settings.max_upload_bytes = 64
 
     obs_id = _create_observation(client)
     big = b"\x89PNG\r\n\x1a\n" + (b"\x00" * 1024)

--- a/server/tests/test_auth_orcid.py
+++ b/server/tests/test_auth_orcid.py
@@ -4,10 +4,12 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, inspect
+from sqlalchemy import create_engine, func, inspect, select
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from zapp_atlas.auth.services import ORCID_STATE_COOKIE
+from zapp_atlas.auth.models import OrcidAuthToken
+from zapp_atlas.auth.services import ORCID_STATE_COOKIE, store_orcid_token
 from zapp_atlas.db import init_db
 from zapp_atlas.settings import DEFAULT_ORCID_REDIRECT_URI
 
@@ -91,6 +93,48 @@ def test_registered_callback_rejects_state_mismatch(
     assert "state did not match" in res.text
 
 
+def test_store_orcid_token_updates_existing_identity() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    init_db(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        first = store_orcid_token(
+            session,
+            {
+                "access_token": "first-access-token",
+                "refresh_token": "first-refresh-token",
+                "token_type": "bearer",
+                "expires_in": 100,
+                "scope": "/authenticate",
+                "name": "Sofia Garcia",
+                "orcid": "0000-0001-2345-6789",
+            },
+        )
+        second = store_orcid_token(
+            session,
+            {
+                "access_token": "second-access-token",
+                "refresh_token": "second-refresh-token",
+                "token_type": "bearer",
+                "expires_in": 200,
+                "scope": "/authenticate",
+                "name": "Dr. Sofia Garcia",
+                "orcid": "0000-0001-2345-6789",
+            },
+        )
+
+        token_count = session.scalar(select(func.count()).select_from(OrcidAuthToken))
+
+    assert second.id == first.id
+    assert token_count == 1
+    assert second.name == "Dr. Sofia Garcia"
+
+
 def test_orcid_table_is_registered_with_init_db() -> None:
     engine = create_engine(
         "sqlite:///:memory:",
@@ -100,4 +144,12 @@ def test_orcid_table_is_registered_with_init_db() -> None:
 
     init_db(engine)
 
-    assert "OrcidAuthToken" in inspect(engine).get_table_names()
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("OrcidAuthToken")}
+    indexes = inspector.get_indexes("OrcidAuthToken")
+
+    assert "OrcidAuthToken" in inspector.get_table_names()
+    assert "orcid_id" in columns
+    assert any(index["unique"] and index["column_names"] == ["orcid_id"] for index in indexes)
+    assert "access_token" not in columns
+    assert "refresh_token" not in columns

--- a/server/tests/test_auth_orcid.py
+++ b/server/tests/test_auth_orcid.py
@@ -8,11 +8,11 @@ from sqlalchemy import create_engine, func, inspect, select
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from zapp_atlas.auth.models import OrcidAuthToken
+from zapp_atlas.auth.models import OrcidIdentity
 from zapp_atlas.auth.services import (
     ORCID_AUTH_COOKIE,
     ORCID_STATE_COOKIE,
-    store_orcid_token,
+    store_orcid_identity,
 )
 from zapp_atlas.db import init_db
 from zapp_atlas.settings import DEFAULT_ORCID_REDIRECT_URI
@@ -111,7 +111,7 @@ def test_orcid_logout_clears_auth_cookie(client: TestClient) -> None:
     assert res.cookies.get(ORCID_AUTH_COOKIE) is None
 
 
-def test_store_orcid_token_updates_existing_identity() -> None:
+def test_store_orcid_identity_updates_existing_identity() -> None:
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -121,7 +121,7 @@ def test_store_orcid_token_updates_existing_identity() -> None:
     Session = sessionmaker(bind=engine)
 
     with Session() as session:
-        first = store_orcid_token(
+        first = store_orcid_identity(
             session,
             {
                 "access_token": "first-access-token",
@@ -133,7 +133,7 @@ def test_store_orcid_token_updates_existing_identity() -> None:
                 "orcid": "0000-0001-2345-6789",
             },
         )
-        second = store_orcid_token(
+        second = store_orcid_identity(
             session,
             {
                 "access_token": "second-access-token",
@@ -146,14 +146,14 @@ def test_store_orcid_token_updates_existing_identity() -> None:
             },
         )
 
-        token_count = session.scalar(select(func.count()).select_from(OrcidAuthToken))
+        identity_count = session.scalar(select(func.count()).select_from(OrcidIdentity))
 
     assert second.id == first.id
-    assert token_count == 1
+    assert identity_count == 1
     assert second.name == "Dr. Sofia Garcia"
 
 
-def test_orcid_table_is_registered_with_init_db() -> None:
+def test_orcid_identity_table_is_registered_with_init_db() -> None:
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -163,10 +163,10 @@ def test_orcid_table_is_registered_with_init_db() -> None:
     init_db(engine)
 
     inspector = inspect(engine)
-    columns = {column["name"] for column in inspector.get_columns("OrcidAuthToken")}
-    indexes = inspector.get_indexes("OrcidAuthToken")
+    columns = {column["name"] for column in inspector.get_columns("OrcidIdentity")}
+    indexes = inspector.get_indexes("OrcidIdentity")
 
-    assert "OrcidAuthToken" in inspector.get_table_names()
+    assert "OrcidIdentity" in inspector.get_table_names()
     assert "orcid_id" in columns
     assert any(index["unique"] and index["column_names"] == ["orcid_id"] for index in indexes)
     assert "access_token" not in columns

--- a/server/tests/test_auth_orcid.py
+++ b/server/tests/test_auth_orcid.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.pool import StaticPool
+
+from zapp_atlas.auth.services import ORCID_STATE_COOKIE
+from zapp_atlas.db import init_db
+
+
+def test_login_page_renders(client: TestClient) -> None:
+    res = client.get("/login")
+
+    assert res.status_code == 200
+    assert "Sign in with ORCID" in res.text
+    assert "/auth/orcid/login" in res.text
+
+
+def test_orcid_login_redirects_to_authorize(
+    client: TestClient, monkeypatch
+) -> None:
+    monkeypatch.setenv("ORCID_CLIENT_ID", "APP-123")
+    monkeypatch.setenv("ORCID_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("ORCID_REDIRECT_URI", "http://127.0.0.1:8000/registered")
+
+    res = client.get("/auth/orcid/login", follow_redirects=False)
+
+    assert res.status_code == 307
+    assert ORCID_STATE_COOKIE in res.cookies
+    location = res.headers["location"]
+    parsed = urlparse(location)
+    query = parse_qs(parsed.query)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "orcid.org"
+    assert parsed.path == "/oauth/authorize"
+    assert query["client_id"] == ["APP-123"]
+    assert query["response_type"] == ["code"]
+    assert query["scope"] == ["/authenticate"]
+    assert query["redirect_uri"] == ["http://localhost.localdomain:5000/registered"]
+    assert query["state"]
+
+
+def test_registered_callback_stores_token_and_redirects(
+    client: TestClient, monkeypatch
+) -> None:
+    monkeypatch.setenv("ORCID_CLIENT_ID", "APP-123")
+    monkeypatch.setenv("ORCID_CLIENT_SECRET", "secret")
+
+    def fake_exchange(config, code):
+        assert code == "oauth-code"
+        return {
+            "access_token": "stored-access-token",
+            "refresh_token": "stored-refresh-token",
+            "token_type": "bearer",
+            "expires_in": 631138518,
+            "scope": "/authenticate",
+            "name": "Sofia Garcia",
+            "orcid": "0000-0001-2345-6789",
+        }
+
+    monkeypatch.setattr("zapp_atlas.auth.router.exchange_code_for_token", fake_exchange)
+    client.cookies.set(ORCID_STATE_COOKIE, "state-value")
+
+    res = client.get(
+        "/registered?code=oauth-code&state=state-value",
+        follow_redirects=False,
+    )
+
+    assert res.status_code == 303
+    assert res.headers["location"].startswith("/login?auth_id=")
+    auth_id = parse_qs(urlparse(res.headers["location"]).query)["auth_id"][0]
+
+    status_res = client.get(f"/auth/orcid/status/{auth_id}")
+    assert status_res.status_code == 200
+    assert "Sofia Garcia" in status_res.text
+    assert "0000-0001-2345-6789" in status_res.text
+    assert "stored-access-token" not in status_res.text
+    assert "stored-refresh-token" not in status_res.text
+
+
+def test_registered_callback_rejects_state_mismatch(
+    client: TestClient, monkeypatch
+) -> None:
+    monkeypatch.setenv("ORCID_CLIENT_ID", "APP-123")
+    monkeypatch.setenv("ORCID_CLIENT_SECRET", "secret")
+    client.cookies.set(ORCID_STATE_COOKIE, "expected")
+
+    res = client.get("/registered?code=oauth-code&state=actual")
+
+    assert res.status_code == 400
+    assert "state did not match" in res.text
+
+
+def test_orcid_table_is_registered_with_init_db() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    init_db(engine)
+
+    assert "OrcidAuthToken" in inspect(engine).get_table_names()
+

--- a/server/tests/test_auth_orcid.py
+++ b/server/tests/test_auth_orcid.py
@@ -9,7 +9,11 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from zapp_atlas.auth.models import OrcidAuthToken
-from zapp_atlas.auth.services import ORCID_STATE_COOKIE, store_orcid_token
+from zapp_atlas.auth.services import (
+    ORCID_AUTH_COOKIE,
+    ORCID_STATE_COOKIE,
+    store_orcid_token,
+)
 from zapp_atlas.db import init_db
 from zapp_atlas.settings import DEFAULT_ORCID_REDIRECT_URI
 
@@ -20,6 +24,10 @@ def test_login_page_renders(client: TestClient) -> None:
     assert res.status_code == 200
     assert "Sign in with ORCID" in res.text
     assert "/auth/orcid/login" in res.text
+    assert "/auth/orcid/logout" in res.text
+    assert "Log out" in res.text
+    assert "auth_id=" not in res.text
+    assert 'hx-get="/auth/orcid/status"' in res.text
 
 
 def test_orcid_login_redirects_to_authorize(client: TestClient) -> None:
@@ -69,10 +77,10 @@ def test_registered_callback_stores_token_and_redirects(client: TestClient) -> N
         )
 
     assert res.status_code == 303
-    assert res.headers["location"].startswith("/login?auth_id=")
-    auth_id = parse_qs(urlparse(res.headers["location"]).query)["auth_id"][0]
+    assert res.headers["location"] == "/login"
+    assert ORCID_AUTH_COOKIE in res.cookies
 
-    status_res = client.get(f"/auth/orcid/status/{auth_id}")
+    status_res = client.get("/auth/orcid/status")
     assert status_res.status_code == 200
     assert "Sofia Garcia" in status_res.text
     assert "0000-0001-2345-6789" in status_res.text
@@ -91,6 +99,16 @@ def test_registered_callback_rejects_state_mismatch(
 
     assert res.status_code == 400
     assert "state did not match" in res.text
+
+
+def test_orcid_logout_clears_auth_cookie(client: TestClient) -> None:
+    client.cookies.set(ORCID_AUTH_COOKIE, "auth-id")
+
+    res = client.post("/auth/orcid/logout", follow_redirects=False)
+
+    assert res.status_code == 303
+    assert res.headers["location"] == "/login"
+    assert res.cookies.get(ORCID_AUTH_COOKIE) is None
 
 
 def test_store_orcid_token_updates_existing_identity() -> None:

--- a/server/tests/test_auth_orcid.py
+++ b/server/tests/test_auth_orcid.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 from fastapi.testclient import TestClient
@@ -8,6 +9,7 @@ from sqlalchemy.pool import StaticPool
 
 from zapp_atlas.auth.services import ORCID_STATE_COOKIE
 from zapp_atlas.db import init_db
+from zapp_atlas.settings import DEFAULT_ORCID_REDIRECT_URI
 
 
 def test_login_page_renders(client: TestClient) -> None:
@@ -18,12 +20,10 @@ def test_login_page_renders(client: TestClient) -> None:
     assert "/auth/orcid/login" in res.text
 
 
-def test_orcid_login_redirects_to_authorize(
-    client: TestClient, monkeypatch
-) -> None:
-    monkeypatch.setenv("ORCID_CLIENT_ID", "APP-123")
-    monkeypatch.setenv("ORCID_CLIENT_SECRET", "secret")
-    monkeypatch.setenv("ORCID_REDIRECT_URI", "http://127.0.0.1:8000/registered")
+def test_orcid_login_redirects_to_authorize(client: TestClient) -> None:
+    client.app.state.settings.orcid_client_id = "APP-123"
+    client.app.state.settings.orcid_client_secret = "secret"
+    client.app.state.settings.orcid_redirect_uri = DEFAULT_ORCID_REDIRECT_URI
 
     res = client.get("/auth/orcid/login", follow_redirects=False)
 
@@ -38,15 +38,13 @@ def test_orcid_login_redirects_to_authorize(
     assert query["client_id"] == ["APP-123"]
     assert query["response_type"] == ["code"]
     assert query["scope"] == ["/authenticate"]
-    assert query["redirect_uri"] == ["http://localhost.localdomain:5000/registered"]
+    assert query["redirect_uri"] == [DEFAULT_ORCID_REDIRECT_URI]
     assert query["state"]
 
 
-def test_registered_callback_stores_token_and_redirects(
-    client: TestClient, monkeypatch
-) -> None:
-    monkeypatch.setenv("ORCID_CLIENT_ID", "APP-123")
-    monkeypatch.setenv("ORCID_CLIENT_SECRET", "secret")
+def test_registered_callback_stores_token_and_redirects(client: TestClient) -> None:
+    client.app.state.settings.orcid_client_id = "APP-123"
+    client.app.state.settings.orcid_client_secret = "secret"
 
     def fake_exchange(config, code):
         assert code == "oauth-code"
@@ -60,13 +58,13 @@ def test_registered_callback_stores_token_and_redirects(
             "orcid": "0000-0001-2345-6789",
         }
 
-    monkeypatch.setattr("zapp_atlas.auth.router.exchange_code_for_token", fake_exchange)
     client.cookies.set(ORCID_STATE_COOKIE, "state-value")
 
-    res = client.get(
-        "/registered?code=oauth-code&state=state-value",
-        follow_redirects=False,
-    )
+    with patch("zapp_atlas.auth.router.exchange_code_for_token", fake_exchange):
+        res = client.get(
+            "/registered?code=oauth-code&state=state-value",
+            follow_redirects=False,
+        )
 
     assert res.status_code == 303
     assert res.headers["location"].startswith("/login?auth_id=")
@@ -81,10 +79,10 @@ def test_registered_callback_stores_token_and_redirects(
 
 
 def test_registered_callback_rejects_state_mismatch(
-    client: TestClient, monkeypatch
+    client: TestClient,
 ) -> None:
-    monkeypatch.setenv("ORCID_CLIENT_ID", "APP-123")
-    monkeypatch.setenv("ORCID_CLIENT_SECRET", "secret")
+    client.app.state.settings.orcid_client_id = "APP-123"
+    client.app.state.settings.orcid_client_secret = "secret"
     client.cookies.set(ORCID_STATE_COOKIE, "expected")
 
     res = client.get("/registered?code=oauth-code&state=actual")
@@ -103,4 +101,3 @@ def test_orcid_table_is_registered_with_init_db() -> None:
     init_db(engine)
 
     assert "OrcidAuthToken" in inspect(engine).get_table_names()
-

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -832,6 +832,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -948,6 +962,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -1583,6 +1606,7 @@ dependencies = [
     { name = "boto3" },
     { name = "fastapi" },
     { name = "linkml" },
+    { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "sqlalchemy" },
     { name = "uvicorn" },
@@ -1599,6 +1623,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.35" },
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "linkml", git = "https://github.com/linkml/linkml?subdirectory=packages%2Flinkml&rev=820b2473d94d43646fc96f4ad5dd42eb86be3bfa" },
+    { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },


### PR DESCRIPTION
Messages from the two commits say it best.

* 029aec1 adds ORCID OAuth flow and makes a dummy login page.
* 2641f3d consolidates settings into one centralized  `AppSettings` class using `pydantic-settings`.