### PR TITLE
Add research group schema definition as sqlalchemy within the auth model

### DIFF
--- a/server/src/zapp_atlas/auth/models.py
+++ b/server/src/zapp_atlas/auth/models.py
@@ -37,7 +37,7 @@ class ResearchGroupMember(Base):
     """ A join class between users and research groups that specifies the relationship permissions """
     id: Mapped[int] = mapped_column(Integer(), primary_key=True, autoincrement=True)
     user: Mapped[str] = relationship(foreign_keys="[OrcidIdentity.id]")
-    role: Mapped[str] = mapped_column(Enum('owner','editor'))
+    role: Mapped[str] = mapped_column(Enum('admin','member'))
     group: Mapped[int] = relationship(foreign_keys=['ResearchGroup.id'])
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(

--- a/server/src/zapp_atlas/auth/models.py
+++ b/server/src/zapp_atlas/auth/models.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, Text
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import DateTime, Text, Integer, Enum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from zapp_atlas.schema._gen.sqla import Base
 
@@ -23,6 +23,22 @@ class OrcidIdentity(Base):
     )
     orcid_id: Mapped[str] = mapped_column(Text(), unique=True, index=True)
     name: Mapped[str | None] = mapped_column(Text())
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )
+
+class ResearchGroup(Base):
+    """ A named collection of users that have shared editing access """
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(Text())
+
+class ResearchGroupMember(Base):
+    """ A join class between users and research groups that specifies the relationship permissions """
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True, autoincrement=True)
+    user: Mapped[str] = relationship(foreign_keys="[OrcidIdentity.id]")
+    role: Mapped[str] = mapped_column(Enum('owner','editor'))
+    group: Mapped[int] = relationship(foreign_keys=['ResearchGroup.id'])
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, onupdate=_utcnow

--- a/server/src/zapp_atlas/schema/zebrafish_toxicology_atlas_schema.yaml
+++ b/server/src/zapp_atlas/schema/zebrafish_toxicology_atlas_schema.yaml
@@ -59,6 +59,7 @@ classes:
       - publication
       - annotator
       - lab
+      - group
 
   Experiment:
     is_a: ZappEntity

--- a/server/src/zapp_atlas/schema/zebrafish_toxicology_atlas_schema.yaml
+++ b/server/src/zapp_atlas/schema/zebrafish_toxicology_atlas_schema.yaml
@@ -59,7 +59,6 @@ classes:
       - publication
       - annotator
       - lab
-      - group
 
   Experiment:
     is_a: ZappEntity


### PR DESCRIPTION
Adds ResearchGroup table with id (generated by sqlalchemy, I think not an actual db sequence) and name, as well as ResearchGroupMember join class between user and group, with a role enum (owner/editor) and created_at/updated_at dates populated by sqlalchemy.
