### PR TITLE
Schema: move ResearchGroup to LinkML and add chemical-cabinet & fish-tank join tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,20 @@ single source of truth for the Pydantic models, the SQLAlchemy tables, the
 client's TypeScript types, and the client's JSON Schema. Edit the YAML and run
 `cd server && make schema`. Generated files carry a `DO NOT EDIT` header.
 
+Two things about that codegen are easy to get wrong:
+
+- **Keep it runnable from a bare `uv sync`.** It once shelled out to `jq`, which
+  is not a declared dependency: on a machine without it the recipe truncated the
+  client's JSON Schema to zero bytes, and every later run reported "Nothing to be
+  done". `.DELETE_ON_ERROR` now removes a half-written target so the next run
+  rebuilds it, but the better protection is not reaching for outside tools.
+- **`unique_keys` and timestamps are applied after generation.** `gen-sqla`
+  renders neither, so `schema/constraints.py` reads them back out of the YAML at
+  import and attaches them to the generated tables. Declare them in the schema as
+  usual; nothing needs restating in Python. Note that a slot does not always
+  become a column of the same name — an inlined slot whose range has an
+  identifier becomes `<slot>_<identifier>` (`fish` → `fish_zfin_id`).
+
 **All HTML lives in Jinja templates.** Every document and fragment the app
 returns — pages, htmx partials, error states, and the React client's host
 document — renders through the shared environment in `html/templating.py`, from

--- a/client/src/schema/index.ts
+++ b/client/src/schema/index.ts
@@ -19,6 +19,20 @@ export type PhenotypeTermTermUri = string;
 export type ExposureRouteTermUri = string;
 export type ExposureTypeTermUri = string;
 export type FishZfinId = string;
+export type ResearchGroupId = string;
+export type ResearchGroupMemberId = string;
+export type ChemicalCabinetEntryId = string;
+export type FishTankEntryId = string;
+/**
+* An enumeration of permission levels within a research group.
+*/
+export enum ResearchGroupRoleEnum {
+    
+    /** Can manage group membership as well as the group's data. */
+    admin = "admin",
+    /** Can edit the group's data. */
+    member = "member",
+};
 /**
 * An enumeration of severity levels for phenotypes.
 */
@@ -405,6 +419,50 @@ export interface ExposureType extends OntologyEntity {
 export interface Fish extends ZfinEntity {
     /** Name or label of an entity. */
     name: string,
+}
+
+
+/**
+ * A named collection of users that have shared editing access.
+ */
+export interface ResearchGroup extends ZappEntity {
+    /** Name or label of an entity. */
+    name: string,
+}
+
+
+/**
+ * Membership of an ORCID identity in a research group.
+ */
+export interface ResearchGroupMember extends ZappEntity {
+    /** The research group an entry belongs to. */
+    research_group: ResearchGroupId,
+    /** ORCID identifier of a research group member. */
+    member: string,
+    /** A member's permission level within a research group. */
+    role: string,
+}
+
+
+/**
+ * A chemical a research group keeps on hand. Recorded once, then reused to pre-fill curation instead of re-searching the chemical each time.
+ */
+export interface ChemicalCabinetEntry extends ZappEntity {
+    /** The research group an entry belongs to. */
+    research_group: ResearchGroupId,
+    /** Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical. */
+    chemical_id: string,
+}
+
+
+/**
+ * A fish line a research group maintains. Recorded once, then reused to pre-fill curation instead of re-searching the line each time.
+ */
+export interface FishTankEntry extends ZappEntity {
+    /** The research group an entry belongs to. */
+    research_group: ResearchGroupId,
+    /** The fish line the group maintains. */
+    fish: Fish,
 }
 
 

--- a/client/src/schema/schema.json
+++ b/client/src/schema/schema.json
@@ -1,6 +1,31 @@
 {
   "$comment": "GENERATED FILE. DO NOT EDIT. Regenerate with `make schema`.",
   "$defs": {
+    "ChemicalCabinetEntry": {
+      "additionalProperties": false,
+      "description": "A chemical a research group keeps on hand. Recorded once, then reused to pre-fill curation instead of re-searching the chemical each time.",
+      "properties": {
+        "chemical_id": {
+          "description": "Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Auto-generated integer identifier.",
+          "type": "integer"
+        },
+        "research_group": {
+          "description": "The research group an entry belongs to.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "research_group",
+        "chemical_id",
+        "id"
+      ],
+      "title": "ChemicalCabinetEntry",
+      "type": "object"
+    },
     "Control": {
       "additionalProperties": false,
       "description": "A subject serves as a reference for assessing phenotypic outcome in the phenotype observation set.",
@@ -337,6 +362,31 @@
       "title": "Fish",
       "type": "object"
     },
+    "FishTankEntry": {
+      "additionalProperties": false,
+      "description": "A fish line a research group maintains. Recorded once, then reused to pre-fill curation instead of re-searching the line each time.",
+      "properties": {
+        "fish": {
+          "$ref": "#/$defs/Fish",
+          "description": "The fish line the group maintains."
+        },
+        "id": {
+          "description": "Auto-generated integer identifier.",
+          "type": "integer"
+        },
+        "research_group": {
+          "description": "The research group an entry belongs to.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "research_group",
+        "fish",
+        "id"
+      ],
+      "title": "FishTankEntry",
+      "type": "object"
+    },
     "Image": {
       "additionalProperties": false,
       "description": "An image associated with a phenotype observation.",
@@ -612,6 +662,66 @@
       ],
       "title": "Regimen",
       "type": "object"
+    },
+    "ResearchGroup": {
+      "additionalProperties": false,
+      "description": "A named collection of users that have shared editing access.",
+      "properties": {
+        "id": {
+          "description": "Auto-generated integer identifier.",
+          "type": "integer"
+        },
+        "name": {
+          "description": "Name or label of an entity.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "id"
+      ],
+      "title": "ResearchGroup",
+      "type": "object"
+    },
+    "ResearchGroupMember": {
+      "additionalProperties": false,
+      "description": "Membership of an ORCID identity in a research group.",
+      "properties": {
+        "id": {
+          "description": "Auto-generated integer identifier.",
+          "type": "integer"
+        },
+        "member": {
+          "description": "ORCID identifier of a research group member.",
+          "pattern": "^ORCID:[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$",
+          "type": "string"
+        },
+        "research_group": {
+          "description": "The research group an entry belongs to.",
+          "type": "integer"
+        },
+        "role": {
+          "$ref": "#/$defs/ResearchGroupRoleEnum",
+          "description": "A member's permission level within a research group."
+        }
+      },
+      "required": [
+        "research_group",
+        "member",
+        "role",
+        "id"
+      ],
+      "title": "ResearchGroupMember",
+      "type": "object"
+    },
+    "ResearchGroupRoleEnum": {
+      "description": "An enumeration of permission levels within a research group.",
+      "enum": [
+        "admin",
+        "member"
+      ],
+      "title": "ResearchGroupRoleEnum",
+      "type": "string"
     },
     "SeverityEnum": {
       "description": "An enumeration of severity levels for phenotypes.",

--- a/server/Makefile
+++ b/server/Makefile
@@ -6,6 +6,11 @@ SQLA_OUTPUT := $(SCHEMA_DIR)/_gen/sqla.py
 TS_OUTPUT := ../client/src/schema/index.ts
 JSON_SCHEMA_OUTPUT := ../client/src/schema/schema.json
 
+# Every recipe here redirects into its target, so a failing command leaves a
+# truncated file behind — which make would then consider up to date, silently
+# shipping an empty artifact. Delete such targets so the next run rebuilds.
+.DELETE_ON_ERROR:
+
 .PHONY: schema
 schema: $(PYDANTIC_OUTPUT) $(SQLA_OUTPUT) $(PYDANTIC_CRUD_OUTPUT) $(TS_OUTPUT) $(JSON_SCHEMA_OUTPUT)
 
@@ -33,9 +38,18 @@ $(TS_OUTPUT): $(LINKML_SCHEMA)
 	uv run gen-typescript $< >>$@
 
 # JSON Schema for the client: runtime validation (Ajv) + type-safe unmarshalling.
-# JSON has no comments, so the "do not edit" notice rides in the standard JSON Schema
-# `$$comment` keyword, injected as the first key. ($$ escapes $ for Make.)
+# JSON has no comments, so the "do not edit" notice rides in the standard JSON
+# Schema `$$comment` keyword, injected as the first key. ($$ escapes $ for Make.)
+# Injected with Python rather than jq so the codegen needs nothing outside the
+# uv environment.
+define JSON_SCHEMA_NOTICE
+import json, sys
+notice = "GENERATED FILE. DO NOT EDIT. Regenerate with `make schema`."
+json.dump({"$$comment": notice, **json.load(sys.stdin)}, sys.stdout, indent=2, ensure_ascii=False)
+print()
+endef
+export JSON_SCHEMA_NOTICE
+
 $(JSON_SCHEMA_OUTPUT): $(LINKML_SCHEMA)
 	mkdir -p $(@D)
-	uv run gen-json-schema $< \
-		| jq '{"$$comment": "GENERATED FILE. DO NOT EDIT. Regenerate with `make schema`."} + .' > $@
+	uv run gen-json-schema $< | uv run python -c "$$JSON_SCHEMA_NOTICE" > $@

--- a/server/src/zapp_atlas/auth/models.py
+++ b/server/src/zapp_atlas/auth/models.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, ForeignKey, Text, Integer, Enum
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import DateTime, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
-from zapp_atlas.schema._gen.sqla import Base
+from zapp_atlas.schema.sqla import Base
 
 
 def _utcnow() -> datetime:
@@ -23,30 +23,6 @@ class OrcidIdentity(Base):
     )
     orcid_id: Mapped[str] = mapped_column(Text(), unique=True, index=True)
     name: Mapped[str | None] = mapped_column(Text())
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
-    )
-
-class ResearchGroup(Base):
-    """ A named collection of users that have shared editing access """
-
-    __tablename__ = "ResearchGroup"
-
-    id: Mapped[int] = mapped_column(Integer(), primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(Text())
-
-class ResearchGroupMember(Base):
-    """ A join class between users and research groups that specifies the relationship permissions """
-
-    __tablename__ = "ResearchGroupMember"
-
-    id: Mapped[int] = mapped_column(Integer(), primary_key=True, autoincrement=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("OrcidIdentity.id"))
-    group_id: Mapped[int] = mapped_column(ForeignKey("ResearchGroup.id"))
-    role: Mapped[str] = mapped_column(Enum('admin', 'member', name="research_group_role"))
-    user: Mapped[OrcidIdentity] = relationship()
-    group: Mapped[ResearchGroup] = relationship()
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, onupdate=_utcnow

--- a/server/src/zapp_atlas/schema/_gen/pydantic.py
+++ b/server/src/zapp_atlas/schema/_gen/pydantic.py
@@ -111,6 +111,20 @@ linkml_meta = LinkMLMeta({'default_prefix': 'zebrafish_toxicology_atlas_schema',
      'source_file': 'src/zapp_atlas/schema/zebrafish_toxicology_atlas_schema.yaml',
      'title': 'zebrafish-toxicology-atlas-schema'} )
 
+class ResearchGroupRoleEnum(str, Enum):
+    """
+    An enumeration of permission levels within a research group.
+    """
+    admin = "admin"
+    """
+    Can manage group membership as well as the group's data.
+    """
+    member = "member"
+    """
+    Can edit the group's data.
+    """
+
+
 class SeverityEnum(str, Enum):
     """
     An enumeration of severity levels for phenotypes.
@@ -442,7 +456,7 @@ class Experiment(ZappEntity):
 
     standard_rearing_condition: Optional[bool] = Field(default=None, description="""An indication of whether the subject was maintained under standard conditions, which are the established, consistent environmental and husbandry parameters (such as temperature, lighting, diet, and housing) designed to minimize variability and ensure reproducibility in experiments.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     rearing_condition_comment: Optional[str] = Field(default=None, description="""Comments on rearing conditions, for example, about how conditions deviated from standard parameters.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
-    fish: Optional[Fish] = Field(default=None, description="""The fish subject of the experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
+    fish: Optional[Fish] = Field(default=None, description="""The fish subject of the experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment', 'FishTankEntry']} })
     control: Optional[list[Control]] = Field(default=None, description="""An observation that serves as the reference for assessing phenotypic outcome.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     exposure_event: Optional[list[ExposureEvent]] = Field(default=None, description="""The exposure event in an experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
@@ -532,7 +546,7 @@ class StressorChemical(ZappEntity):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema'})
 
-    chemical_id: Optional[str] = Field(default=None, description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
+    chemical_id: Optional[str] = Field(default=None, description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical', 'ChemicalCabinetEntry']} })
     cas_id: Optional[str] = Field(default=None, description="""CAS identifier for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
     chemical_name: Optional[str] = Field(default=None, description="""Name of the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
     synonym: Optional[list[str]] = Field(default=None, description="""Other names for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
@@ -631,7 +645,7 @@ class Fish(ZfinEntity):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema',
          'slot_usage': {'name': {'name': 'name', 'required': True}}})
 
-    name: str = Field(default=..., description="""Name or label of an entity.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Fish']} })
+    name: str = Field(default=..., description="""Name or label of an entity.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Fish', 'ResearchGroup']} })
     zfin_id: str = Field(default=..., description="""ZFIN database identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZfinEntity']} })
 
     @field_validator('zfin_id')
@@ -646,6 +660,80 @@ class Fish(ZfinEntity):
             err_msg = f"Invalid zfin_id format: {v}"
             raise ValueError(err_msg)
         return v
+
+
+class ResearchGroup(ZappEntity):
+    """
+    A named collection of users that have shared editing access.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema',
+         'slot_usage': {'name': {'name': 'name', 'required': True}}})
+
+    name: str = Field(default=..., description="""Name or label of an entity.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Fish', 'ResearchGroup']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
+
+
+class ResearchGroupMember(ZappEntity):
+    """
+    Membership of an ORCID identity in a research group.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'timestamped': {'tag': 'timestamped', 'value': True}},
+         'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema',
+         'unique_keys': {'membership_grain': {'unique_key_name': 'membership_grain',
+                                              'unique_key_slots': ['research_group',
+                                                                   'member']}}})
+
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    member: str = Field(default=..., description="""ORCID identifier of a research group member.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember']} })
+    role: ResearchGroupRoleEnum = Field(default=..., description="""A member's permission level within a research group.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
+
+    @field_validator('member')
+    def pattern_member(cls, v):
+        pattern=re.compile(r"^ORCID:[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid member format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid member format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class ChemicalCabinetEntry(ZappEntity):
+    """
+    A chemical a research group keeps on hand. Recorded once, then reused to pre-fill curation instead of re-searching the chemical each time.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'timestamped': {'tag': 'timestamped', 'value': True}},
+         'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema',
+         'slot_usage': {'chemical_id': {'name': 'chemical_id', 'required': True}},
+         'unique_keys': {'cabinet_grain': {'unique_key_name': 'cabinet_grain',
+                                           'unique_key_slots': ['research_group',
+                                                                'chemical_id']}}})
+
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    chemical_id: str = Field(default=..., description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical', 'ChemicalCabinetEntry']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
+
+
+class FishTankEntry(ZappEntity):
+    """
+    A fish line a research group maintains. Recorded once, then reused to pre-fill curation instead of re-searching the line each time.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'timestamped': {'tag': 'timestamped', 'value': True}},
+         'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema',
+         'slot_usage': {'fish': {'description': 'The fish line the group maintains.',
+                                 'name': 'fish',
+                                 'required': True}},
+         'unique_keys': {'tank_grain': {'unique_key_name': 'tank_grain',
+                                        'unique_key_slots': ['research_group',
+                                                             'fish']}}})
+
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    fish: Fish = Field(default=..., description="""The fish line the group maintains.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment', 'FishTankEntry']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
 
 
 class QuantityValue(ConfiguredBaseModel):
@@ -678,4 +766,8 @@ PhenotypeTerm.model_rebuild()
 ExposureRoute.model_rebuild()
 ExposureType.model_rebuild()
 Fish.model_rebuild()
+ResearchGroup.model_rebuild()
+ResearchGroupMember.model_rebuild()
+ChemicalCabinetEntry.model_rebuild()
+FishTankEntry.model_rebuild()
 QuantityValue.model_rebuild()

--- a/server/src/zapp_atlas/schema/_gen/pydantic_crud.py
+++ b/server/src/zapp_atlas/schema/_gen/pydantic_crud.py
@@ -119,6 +119,20 @@ linkml_meta = LinkMLMeta({'default_prefix': 'zebrafish_toxicology_atlas_schema',
      'source_file': 'src/zapp_atlas/schema/zebrafish_toxicology_atlas_schema.yaml',
      'title': 'zebrafish-toxicology-atlas-schema'} )
 
+class ResearchGroupRoleEnum(str, Enum):
+    """
+    An enumeration of permission levels within a research group.
+    """
+    admin = "admin"
+    """
+    Can manage group membership as well as the group's data.
+    """
+    member = "member"
+    """
+    Can edit the group's data.
+    """
+
+
 class SeverityEnum(str, Enum):
     """
     An enumeration of severity levels for phenotypes.
@@ -559,7 +573,7 @@ class Experiment(ZappEntity):
 
     standard_rearing_condition: Optional[bool] = Field(default=None, description="""An indication of whether the subject was maintained under standard conditions, which are the established, consistent environmental and husbandry parameters (such as temperature, lighting, diet, and housing) designed to minimize variability and ensure reproducibility in experiments.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     rearing_condition_comment: Optional[str] = Field(default=None, description="""Comments on rearing conditions, for example, about how conditions deviated from standard parameters.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
-    fish: Optional[Fish] = Field(default=None, description="""The fish subject of the experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
+    fish: Optional[Fish] = Field(default=None, description="""The fish subject of the experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment', 'FishTankEntry']} })
     control: Optional[list[Control]] = Field(default=None, description="""An observation that serves as the reference for assessing phenotypic outcome.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     exposure_event: Optional[list[ExposureEvent]] = Field(default=None, description="""The exposure event in an experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
@@ -571,7 +585,7 @@ class ExperimentCreate(ConfiguredBaseModel):
     """
     standard_rearing_condition: Optional[bool] = Field(default=None, description="""An indication of whether the subject was maintained under standard conditions, which are the established, consistent environmental and husbandry parameters (such as temperature, lighting, diet, and housing) designed to minimize variability and ensure reproducibility in experiments.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     rearing_condition_comment: Optional[str] = Field(default=None, description="""Comments on rearing conditions, for example, about how conditions deviated from standard parameters.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
-    fish: Optional[Fish] = Field(default=None, description="""The fish subject of the experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
+    fish: Optional[Fish] = Field(default=None, description="""The fish subject of the experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment', 'FishTankEntry']} })
     control: Optional[list[ControlCreate]] = Field(default=None, description="""An observation that serves as the reference for assessing phenotypic outcome.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     exposure_event: Optional[list[ExposureEventCreate]] = Field(default=None, description="""The exposure event in an experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
 
@@ -582,7 +596,7 @@ class ExperimentUpdate(ConfiguredBaseModel):
     """
     standard_rearing_condition: Optional[bool] = Field(default=None, description="""An indication of whether the subject was maintained under standard conditions, which are the established, consistent environmental and husbandry parameters (such as temperature, lighting, diet, and housing) designed to minimize variability and ensure reproducibility in experiments.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     rearing_condition_comment: Optional[str] = Field(default=None, description="""Comments on rearing conditions, for example, about how conditions deviated from standard parameters.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
-    fish: Optional[Fish] = Field(default=None, description="""The fish subject of the experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
+    fish: Optional[Fish] = Field(default=None, description="""The fish subject of the experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment', 'FishTankEntry']} })
     control: Optional[list[Control]] = Field(default=None, description="""An observation that serves as the reference for assessing phenotypic outcome.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     exposure_event: Optional[list[ExposureEvent]] = Field(default=None, description="""The exposure event in an experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
 
@@ -593,7 +607,7 @@ class ExperimentRead(ReadBaseModel):
     """
     standard_rearing_condition: Optional[bool] = Field(default=None, description="""An indication of whether the subject was maintained under standard conditions, which are the established, consistent environmental and husbandry parameters (such as temperature, lighting, diet, and housing) designed to minimize variability and ensure reproducibility in experiments.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     rearing_condition_comment: Optional[str] = Field(default=None, description="""Comments on rearing conditions, for example, about how conditions deviated from standard parameters.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
-    fish: Optional[FishRead] = Field(default=None, description="""The fish subject of the experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
+    fish: Optional[FishRead] = Field(default=None, description="""The fish subject of the experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment', 'FishTankEntry']} })
     control: Optional[list[ControlRead]] = Field(default=None, description="""An observation that serves as the reference for assessing phenotypic outcome.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     exposure_event: Optional[list[ExposureEventRead]] = Field(default=None, description="""The exposure event in an experiment.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment']} })
     id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
@@ -874,7 +888,7 @@ class StressorChemical(ZappEntity):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema'})
 
-    chemical_id: Optional[str] = Field(default=None, description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
+    chemical_id: Optional[str] = Field(default=None, description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical', 'ChemicalCabinetEntry']} })
     cas_id: Optional[str] = Field(default=None, description="""CAS identifier for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
     chemical_name: Optional[str] = Field(default=None, description="""Name of the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
     synonym: Optional[list[str]] = Field(default=None, description="""Other names for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
@@ -891,7 +905,7 @@ class StressorChemicalCreate(ConfiguredBaseModel):
     """
     Create schema for StressorChemical — id is server-generated.
     """
-    chemical_id: Optional[str] = Field(default=None, description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
+    chemical_id: Optional[str] = Field(default=None, description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical', 'ChemicalCabinetEntry']} })
     cas_id: Optional[str] = Field(default=None, description="""CAS identifier for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
     chemical_name: Optional[str] = Field(default=None, description="""Name of the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
     synonym: Optional[list[str]] = Field(default=None, description="""Other names for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
@@ -907,7 +921,7 @@ class StressorChemicalUpdate(ConfiguredBaseModel):
     """
     Update schema for StressorChemical — all fields optional for partial updates.
     """
-    chemical_id: Optional[str] = Field(default=None, description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
+    chemical_id: Optional[str] = Field(default=None, description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical', 'ChemicalCabinetEntry']} })
     cas_id: Optional[str] = Field(default=None, description="""CAS identifier for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
     chemical_name: Optional[str] = Field(default=None, description="""Name of the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
     synonym: Optional[list[str]] = Field(default=None, description="""Other names for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
@@ -923,7 +937,7 @@ class StressorChemicalRead(ReadBaseModel):
     """
     Read schema for StressorChemical — from_attributes=True, extra=ignore.
     """
-    chemical_id: Optional[str] = Field(default=None, description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
+    chemical_id: Optional[str] = Field(default=None, description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical', 'ChemicalCabinetEntry']} })
     cas_id: Optional[str] = Field(default=None, description="""CAS identifier for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
     chemical_name: Optional[str] = Field(default=None, description="""Name of the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
     synonym: Optional[list[str]] = Field(default=None, description="""Other names for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical']} })
@@ -1148,7 +1162,7 @@ class Fish(ZfinEntity):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema',
          'slot_usage': {'name': {'name': 'name', 'required': True}}})
 
-    name: str = Field(default=..., description="""Name or label of an entity.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Fish']} })
+    name: str = Field(default=..., description="""Name or label of an entity.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Fish', 'ResearchGroup']} })
     zfin_id: str = Field(default=..., description="""ZFIN database identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZfinEntity']} })
 
     @field_validator('zfin_id')
@@ -1169,7 +1183,7 @@ class FishRead(ReadBaseModel):
     """
     Read schema for Fish — from_attributes=True, extra=ignore.
     """
-    name: str = Field(default=..., description="""Name or label of an entity.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Fish']} })
+    name: str = Field(default=..., description="""Name or label of an entity.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Fish', 'ResearchGroup']} })
     zfin_id: str = Field(default=..., description="""ZFIN database identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZfinEntity']} })
 
     @field_validator('zfin_id')
@@ -1184,6 +1198,219 @@ class FishRead(ReadBaseModel):
             err_msg = f"Invalid zfin_id format: {v}"
             raise ValueError(err_msg)
         return v
+
+
+class ResearchGroup(ZappEntity):
+    """
+    A named collection of users that have shared editing access.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema',
+         'slot_usage': {'name': {'name': 'name', 'required': True}}})
+
+    name: str = Field(default=..., description="""Name or label of an entity.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Fish', 'ResearchGroup']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
+
+
+class ResearchGroupCreate(ConfiguredBaseModel):
+    """
+    Create schema for ResearchGroup — id is server-generated.
+    """
+    name: str = Field(default=..., description="""Name or label of an entity.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Fish', 'ResearchGroup']} })
+
+
+class ResearchGroupUpdate(ConfiguredBaseModel):
+    """
+    Update schema for ResearchGroup — all fields optional for partial updates.
+    """
+    name: Optional[str] = Field(default=None, description="""Name or label of an entity.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Fish', 'ResearchGroup']} })
+
+
+class ResearchGroupRead(ReadBaseModel):
+    """
+    Read schema for ResearchGroup — from_attributes=True, extra=ignore.
+    """
+    name: str = Field(default=..., description="""Name or label of an entity.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Fish', 'ResearchGroup']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
+
+
+class ResearchGroupMember(ZappEntity):
+    """
+    Membership of an ORCID identity in a research group.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'timestamped': {'tag': 'timestamped', 'value': True}},
+         'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema',
+         'unique_keys': {'membership_grain': {'unique_key_name': 'membership_grain',
+                                              'unique_key_slots': ['research_group',
+                                                                   'member']}}})
+
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    member: str = Field(default=..., description="""ORCID identifier of a research group member.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember']} })
+    role: ResearchGroupRoleEnum = Field(default=..., description="""A member's permission level within a research group.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
+
+    @field_validator('member')
+    def pattern_member(cls, v):
+        pattern=re.compile(r"^ORCID:[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid member format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid member format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class ResearchGroupMemberCreate(ConfiguredBaseModel):
+    """
+    Create schema for ResearchGroupMember — id is server-generated.
+    """
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    member: str = Field(default=..., description="""ORCID identifier of a research group member.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember']} })
+    role: ResearchGroupRoleEnum = Field(default=..., description="""A member's permission level within a research group.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember']} })
+
+    @field_validator('member')
+    def pattern_member(cls, v):
+        pattern=re.compile(r"^ORCID:[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid member format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid member format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class ResearchGroupMemberUpdate(ConfiguredBaseModel):
+    """
+    Update schema for ResearchGroupMember — all fields optional for partial updates.
+    """
+    research_group: Optional[int] = Field(default=None, description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    member: Optional[str] = Field(default=None, description="""ORCID identifier of a research group member.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember']} })
+    role: Optional[ResearchGroupRoleEnum] = Field(default=None, description="""A member's permission level within a research group.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember']} })
+
+    @field_validator('member')
+    def pattern_member(cls, v):
+        pattern=re.compile(r"^ORCID:[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid member format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid member format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class ResearchGroupMemberRead(ReadBaseModel):
+    """
+    Read schema for ResearchGroupMember — from_attributes=True, extra=ignore.
+    """
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    member: str = Field(default=..., description="""ORCID identifier of a research group member.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember']} })
+    role: ResearchGroupRoleEnum = Field(default=..., description="""A member's permission level within a research group.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
+
+    @field_validator('member')
+    def pattern_member(cls, v):
+        pattern=re.compile(r"^ORCID:[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid member format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid member format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class ChemicalCabinetEntry(ZappEntity):
+    """
+    A chemical a research group keeps on hand. Recorded once, then reused to pre-fill curation instead of re-searching the chemical each time.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'timestamped': {'tag': 'timestamped', 'value': True}},
+         'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema',
+         'slot_usage': {'chemical_id': {'name': 'chemical_id', 'required': True}},
+         'unique_keys': {'cabinet_grain': {'unique_key_name': 'cabinet_grain',
+                                           'unique_key_slots': ['research_group',
+                                                                'chemical_id']}}})
+
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    chemical_id: str = Field(default=..., description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical', 'ChemicalCabinetEntry']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
+
+
+class ChemicalCabinetEntryCreate(ConfiguredBaseModel):
+    """
+    Create schema for ChemicalCabinetEntry — id is server-generated.
+    """
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    chemical_id: str = Field(default=..., description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical', 'ChemicalCabinetEntry']} })
+
+
+class ChemicalCabinetEntryUpdate(ConfiguredBaseModel):
+    """
+    Update schema for ChemicalCabinetEntry — all fields optional for partial updates.
+    """
+    research_group: Optional[int] = Field(default=None, description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    chemical_id: Optional[str] = Field(default=None, description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical', 'ChemicalCabinetEntry']} })
+
+
+class ChemicalCabinetEntryRead(ReadBaseModel):
+    """
+    Read schema for ChemicalCabinetEntry — from_attributes=True, extra=ignore.
+    """
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    chemical_id: str = Field(default=..., description="""Chemical identifier (e.g., a CHEBI or other ontology URI) for the chemical.""", json_schema_extra = { "linkml_meta": {'domain_of': ['StressorChemical', 'ChemicalCabinetEntry']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
+
+
+class FishTankEntry(ZappEntity):
+    """
+    A fish line a research group maintains. Recorded once, then reused to pre-fill curation instead of re-searching the line each time.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'annotations': {'timestamped': {'tag': 'timestamped', 'value': True}},
+         'from_schema': 'https://w3id.org/sierra-moxon/zebrafish-toxicology-atlas-schema',
+         'slot_usage': {'fish': {'description': 'The fish line the group maintains.',
+                                 'name': 'fish',
+                                 'required': True}},
+         'unique_keys': {'tank_grain': {'unique_key_name': 'tank_grain',
+                                        'unique_key_slots': ['research_group',
+                                                             'fish']}}})
+
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    fish: Fish = Field(default=..., description="""The fish line the group maintains.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment', 'FishTankEntry']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
+
+
+class FishTankEntryCreate(ConfiguredBaseModel):
+    """
+    Create schema for FishTankEntry — id is server-generated.
+    """
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    fish: Fish = Field(default=..., description="""The fish line the group maintains.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment', 'FishTankEntry']} })
+
+
+class FishTankEntryUpdate(ConfiguredBaseModel):
+    """
+    Update schema for FishTankEntry — all fields optional for partial updates.
+    """
+    research_group: Optional[int] = Field(default=None, description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    fish: Optional[Fish] = Field(default=None, description="""The fish line the group maintains.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment', 'FishTankEntry']} })
+
+
+class FishTankEntryRead(ReadBaseModel):
+    """
+    Read schema for FishTankEntry — from_attributes=True, extra=ignore.
+    """
+    research_group: int = Field(default=..., description="""The research group an entry belongs to.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ResearchGroupMember', 'ChemicalCabinetEntry', 'FishTankEntry']} })
+    fish: FishRead = Field(default=..., description="""The fish line the group maintains.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Experiment', 'FishTankEntry']} })
+    id: int = Field(default=..., description="""Auto-generated integer identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ZappEntity']} })
 
 
 class QuantityValue(ConfiguredBaseModel):
@@ -1261,6 +1488,22 @@ ExposureType.model_rebuild()
 ExposureTypeRead.model_rebuild()
 Fish.model_rebuild()
 FishRead.model_rebuild()
+ResearchGroup.model_rebuild()
+ResearchGroupCreate.model_rebuild()
+ResearchGroupUpdate.model_rebuild()
+ResearchGroupRead.model_rebuild()
+ResearchGroupMember.model_rebuild()
+ResearchGroupMemberCreate.model_rebuild()
+ResearchGroupMemberUpdate.model_rebuild()
+ResearchGroupMemberRead.model_rebuild()
+ChemicalCabinetEntry.model_rebuild()
+ChemicalCabinetEntryCreate.model_rebuild()
+ChemicalCabinetEntryUpdate.model_rebuild()
+ChemicalCabinetEntryRead.model_rebuild()
+FishTankEntry.model_rebuild()
+FishTankEntryCreate.model_rebuild()
+FishTankEntryUpdate.model_rebuild()
+FishTankEntryRead.model_rebuild()
 QuantityValue.model_rebuild()
 QuantityValueRead.model_rebuild()
 

--- a/server/src/zapp_atlas/schema/_gen/sqla.py
+++ b/server/src/zapp_atlas/schema/_gen/sqla.py
@@ -448,3 +448,72 @@ class Fish(ZfinEntity):
 
     __mapper_args__ = {"concrete": True}
 
+
+class ResearchGroup(ZappEntity):
+    """
+    A named collection of users that have shared editing access.
+    """
+
+    __tablename__ = "ResearchGroup"
+
+    name: Mapped[str] = mapped_column(Text())
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True)
+
+    def __repr__(self):
+        return f"ResearchGroup(name={self.name},id={self.id},)"
+
+    __mapper_args__ = {"concrete": True}
+
+
+class ResearchGroupMember(ZappEntity):
+    """
+    Membership of an ORCID identity in a research group.
+    """
+
+    __tablename__ = "ResearchGroupMember"
+
+    research_group: Mapped[int] = mapped_column(Integer(), ForeignKey("ResearchGroup.id"))
+    member: Mapped[str] = mapped_column(Text())
+    role: Mapped[str] = mapped_column(Enum('admin', 'member', name='ResearchGroupRoleEnum'))
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True)
+
+    def __repr__(self):
+        return f"ResearchGroupMember(research_group={self.research_group},member={self.member},role={self.role},id={self.id},)"
+
+    __mapper_args__ = {"concrete": True}
+
+
+class ChemicalCabinetEntry(ZappEntity):
+    """
+    A chemical a research group keeps on hand. Recorded once, then reused to pre-fill curation instead of re-searching the chemical each time.
+    """
+
+    __tablename__ = "ChemicalCabinetEntry"
+
+    research_group: Mapped[int] = mapped_column(Integer(), ForeignKey("ResearchGroup.id"))
+    chemical_id: Mapped[str] = mapped_column(Text())
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True)
+
+    def __repr__(self):
+        return f"ChemicalCabinetEntry(research_group={self.research_group},chemical_id={self.chemical_id},id={self.id},)"
+
+    __mapper_args__ = {"concrete": True}
+
+
+class FishTankEntry(ZappEntity):
+    """
+    A fish line a research group maintains. Recorded once, then reused to pre-fill curation instead of re-searching the line each time.
+    """
+
+    __tablename__ = "FishTankEntry"
+
+    research_group: Mapped[int] = mapped_column(Integer(), ForeignKey("ResearchGroup.id"))
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True)
+    fish_zfin_id: Mapped[str] = mapped_column(Text(), ForeignKey("Fish.zfin_id"))
+    fish: Mapped[Fish | None] = relationship(foreign_keys=[fish_zfin_id])
+
+    def __repr__(self):
+        return f"FishTankEntry(research_group={self.research_group},id={self.id},fish_zfin_id={self.fish_zfin_id},)"
+
+    __mapper_args__ = {"concrete": True}
+

--- a/server/src/zapp_atlas/schema/constraints.py
+++ b/server/src/zapp_atlas/schema/constraints.py
@@ -1,0 +1,78 @@
+"""Constraints the LinkML generator cannot yet emit.
+
+``gen-sqla`` renders neither ``unique_keys`` nor timestamp defaults. Both are
+read back out of the schema and attached to the generated tables, so the YAML
+stays the single source of truth. Delete this module once the generator
+supports them.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from linkml_runtime import SchemaView
+from linkml_runtime.linkml_model.meta import ClassDefinition
+from sqlalchemy import Column, DateTime, Index, Table
+
+from zapp_atlas.schema._gen.sqla import Base
+
+SCHEMA_PATH = Path(__file__).resolve().parent / "zebrafish_toxicology_atlas_schema.yaml"
+
+TIMESTAMPED = "timestamped"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _column(view: SchemaView, table: Table, class_name: str, slot_name: str) -> Column:
+    """Resolve a LinkML slot to the column ``gen-sqla`` generated for it.
+
+    An inlined slot whose range carries an identifier becomes
+    ``<slot>_<identifier>`` (``fish`` -> ``fish_zfin_id``); every other slot
+    keeps its own name.
+    """
+    if slot_name in table.c:
+        return table.c[slot_name]
+
+    identifier = view.get_identifier_slot(view.induced_slot(slot_name, class_name).range)
+    if identifier is not None:
+        qualified = f"{slot_name}_{identifier.name}"
+        if qualified in table.c:
+            return table.c[qualified]
+
+    raise KeyError(f"{class_name}.{slot_name} has no generated column")
+
+
+def _apply_unique_keys(view: SchemaView, model: type, definition: ClassDefinition) -> None:
+    table = model.__table__
+    existing = {index.name for index in table.indexes}
+    for key_name, key in definition.unique_keys.items():
+        name = f"uq_{definition.name}_{key_name}"
+        if name in existing:
+            continue
+        columns = [_column(view, table, definition.name, s) for s in key.unique_key_slots]
+        Index(name, *columns, unique=True)
+
+
+def _apply_timestamps(model: type) -> None:
+    if "created_at" in model.__table__.c:
+        return
+    # Set on the class rather than the table: declarative has already mapped
+    # this model, and only attribute assignment also reaches the mapper.
+    model.created_at = Column(DateTime(timezone=True), default=_utcnow)
+    model.updated_at = Column(DateTime(timezone=True), default=_utcnow, onupdate=_utcnow)
+
+
+def apply_schema_constraints(schema_path: Path = SCHEMA_PATH) -> None:
+    """Attach every schema-declared unique key and timestamp pair. Idempotent."""
+    view = SchemaView(str(schema_path))
+    models = {mapper.class_.__name__: mapper.class_ for mapper in Base.registry.mappers}
+    for class_name, definition in view.all_classes().items():
+        model = models.get(class_name)
+        if model is None:
+            continue
+        _apply_unique_keys(view, model, definition)
+        if TIMESTAMPED in definition.annotations:
+            _apply_timestamps(model)

--- a/server/src/zapp_atlas/schema/sqla.py
+++ b/server/src/zapp_atlas/schema/sqla.py
@@ -1,1 +1,4 @@
 from ._gen.sqla import *
+from .constraints import apply_schema_constraints
+
+apply_schema_constraints()

--- a/server/src/zapp_atlas/schema/zebrafish_toxicology_atlas_schema.yaml
+++ b/server/src/zapp_atlas/schema/zebrafish_toxicology_atlas_schema.yaml
@@ -209,6 +209,70 @@ classes:
       name:
         required: true
 
+  # Operational entities (research groups and what they keep on hand)
+  ResearchGroup:
+    is_a: ZappEntity
+    description: A named collection of users that have shared editing access.
+    slots:
+      - name
+    slot_usage:
+      name:
+        required: true
+
+  ResearchGroupMember:
+    is_a: ZappEntity
+    description: Membership of an ORCID identity in a research group.
+    annotations:
+      timestamped: true
+    slots:
+      - research_group
+      - member
+      - role
+    unique_keys:
+      membership_grain:
+        unique_key_slots:
+          - research_group
+          - member
+
+  ChemicalCabinetEntry:
+    is_a: ZappEntity
+    description: >-
+      A chemical a research group keeps on hand. Recorded once, then reused to
+      pre-fill curation instead of re-searching the chemical each time.
+    annotations:
+      timestamped: true
+    slots:
+      - research_group
+      - chemical_id
+    slot_usage:
+      chemical_id:
+        required: true
+    unique_keys:
+      cabinet_grain:
+        unique_key_slots:
+          - research_group
+          - chemical_id
+
+  FishTankEntry:
+    is_a: ZappEntity
+    description: >-
+      A fish line a research group maintains. Recorded once, then reused to
+      pre-fill curation instead of re-searching the line each time.
+    annotations:
+      timestamped: true
+    slots:
+      - research_group
+      - fish
+    slot_usage:
+      fish:
+        required: true
+        description: The fish line the group maintains.
+    unique_keys:
+      tank_grain:
+        unique_key_slots:
+          - research_group
+          - fish
+
   # Value objects (not entities, inlined)
   QuantityValue:
     description: >-
@@ -445,8 +509,29 @@ slots:
   phenotype_comments:
     description: Comments about the phenotype in the control image.
     range: string
+  research_group:
+    description: The research group an entry belongs to.
+    range: ResearchGroup
+    required: true
+  member:
+    description: ORCID identifier of a research group member.
+    range: uriorcurie
+    required: true
+    pattern: "^ORCID:[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$"
+  role:
+    description: A member's permission level within a research group.
+    range: ResearchGroupRoleEnum
+    required: true
 
 enums:
+
+  ResearchGroupRoleEnum:
+    description: An enumeration of permission levels within a research group.
+    permissible_values:
+      admin:
+        description: Can manage group membership as well as the group's data.
+      member:
+        description: Can edit the group's data.
 
   SeverityEnum:
     description: An enumeration of severity levels for phenotypes.

--- a/server/tests/test_schema_constraints.py
+++ b/server/tests/test_schema_constraints.py
@@ -1,0 +1,101 @@
+"""The schema's ``unique_keys`` and timestamp annotations reach the database.
+
+``gen-sqla`` emits neither, so ``schema.constraints`` supplies them from the
+YAML. These tests lock in that the grain of each join table is actually
+enforced rather than merely declared.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from zapp_atlas.db.db import init_db
+from zapp_atlas.schema.sqla import (
+    ChemicalCabinetEntry,
+    Fish,
+    FishTankEntry,
+    ResearchGroup,
+    ResearchGroupMember,
+)
+
+ORCID = "ORCID:0000-0002-1825-0097"
+ETHANOL = "CHEBI:16236"
+AB_LINE = "ZFIN:ZDB-GENO-960809-7"
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:")
+    init_db(engine)
+    with sessionmaker(bind=engine)() as session:
+        yield session
+
+
+@pytest.fixture
+def group(session: Session) -> ResearchGroup:
+    group = ResearchGroup(name="Test Lab")
+    session.add(group)
+    session.commit()
+    return group
+
+
+def assert_second_insert_rejected(session: Session, row: Callable[[], object]) -> None:
+    """``row()`` must commit once and then violate the unique index."""
+    session.add(row())
+    session.commit()
+    session.add(row())
+    with pytest.raises(IntegrityError):
+        session.commit()
+    session.rollback()
+
+
+def test_cabinet_grain_is_unique_per_group_and_chemical(session, group):
+    assert_second_insert_rejected(
+        session,
+        lambda: ChemicalCabinetEntry(research_group=group.id, chemical_id=ETHANOL),
+    )
+
+
+def test_tank_grain_is_unique_per_group_and_fish(session, group):
+    session.add(Fish(zfin_id=AB_LINE, name="AB"))
+    session.commit()
+    assert_second_insert_rejected(
+        session,
+        lambda: FishTankEntry(research_group=group.id, fish_zfin_id=AB_LINE),
+    )
+
+
+def test_membership_grain_is_unique_per_group_and_member(session, group):
+    assert_second_insert_rejected(
+        session,
+        lambda: ResearchGroupMember(
+            research_group=group.id, member=ORCID, role="admin"
+        ),
+    )
+
+
+def test_two_groups_may_stock_the_same_chemical(session):
+    groups = [ResearchGroup(name="Lab A"), ResearchGroup(name="Lab B")]
+    session.add_all(groups)
+    session.commit()
+
+    session.add_all(
+        ChemicalCabinetEntry(research_group=g.id, chemical_id=ETHANOL) for g in groups
+    )
+    session.commit()
+
+    assert session.query(ChemicalCabinetEntry).count() == 2
+
+
+def test_annotated_classes_get_audit_timestamps(session, group):
+    entry = ChemicalCabinetEntry(research_group=group.id, chemical_id=ETHANOL)
+    session.add(entry)
+    session.commit()
+
+    assert entry.created_at is not None
+    assert entry.updated_at is not None


### PR DESCRIPTION
Closes the structural gap #113 and #114 both depend on. **Structure only** — payload columns stay with their issues: `manufacturer`/`vehicle` (#114), `nickname` (#113).

## What's here

- `ResearchGroup` / `ResearchGroupMember` move from hand-written SQLAlchemy in `auth/models.py` into the LinkML schema. `OrcidIdentity` stays hand-written.
- `ChemicalCabinetEntry` and `FishTankEntry`, each declaring its grain via `unique_keys`.
- `schema/constraints.py` — `gen-sqla` renders neither `unique_keys` nor timestamp defaults, so both are read back out of the YAML at import and attached to the generated tables. Nothing is restated in Python, so there's no mirror to drift.

## Two decisions worth a look

**The cabinet points at a chemical identity, not a row.** `StressorChemical` carries `ExposureEvent_id` — it's a per-exposure child row, not a shared entity — so an FK to it would bind a lab's cabinet to one arbitrary study's chemical. Entries key on `chemical_id` (CURIE) instead. This resolves the open design question in #122, and the same reasoning applies to fish: `Fish.zfin_id` is a required, pattern-constrained PK, so a lab line without a ZFIN ID can't be represented yet. Worth its own issue.

**Membership keys on an ORCID CURIE**, not the previous `OrcidIdentity.id` FK, since `OrcidIdentity` stays outside LinkML. Consistent with the existing `annotator` slot. Nothing consumed these classes, so there's no migration.

## Independent of #121

Verified rather than assumed: built the combined schema (this branch + `data_model_updates`) and generated from it — every class from both present, all three unique indexes resolve, `create_all` succeeds. Names are disjoint; only the regenerated `_gen/` files will conflict, and those resolve by re-running `make schema`.

## Second commit: `make schema` needed an undeclared `jq`

Without it the recipe truncated the client's `schema.json` to zero bytes, then reported "Nothing to be done" on every later run — shipping an empty Ajv schema silently, with no CI to catch it. Now injects the notice with Python (byte-identical output, verified with `jq` off `PATH`) and sets `.DELETE_ON_ERROR`.

## Testing

`uv run pytest` → **62 passed**. The 2 `test_html_edit` failures are pre-existing on `main` (unbuilt React client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)