### PR TITLE
Add deployment previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -24,8 +24,13 @@ jobs:
     name: Deploy preview
     # Fork PRs never receive secrets, so a preview could not be deployed for
     # them; skip rather than fail. Closing is handled by the destroy job.
+    #
+    # The state check matters: `labeled` fires on closed PRs too, so without it
+    # labelling a merged PR would deploy an app that nothing ever destroys —
+    # `closed` has already fired and won't fire again.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.state == 'open'
       && github.event.action != 'closed'
       && github.event.action != 'unlabeled'
       && contains(github.event.pull_request.labels.*.name, 'preview')
@@ -96,5 +101,5 @@ jobs:
           BODY: |
             ### Preview destroyed
 
-            The preview app for this PR has been torn down. Re-add the `preview` label to bring it back.
+            The preview app for this PR has been torn down. While the PR is open, re-adding the `preview` label will bring it back.
         run: gh pr comment "$PR" --edit-last --body "$BODY" || true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,8 +42,12 @@ jobs:
       - name: Create the app if it does not exist
         run: flyctl apps create "$APP" --org "$FLY_ORG" || true
 
+      # --ha=false: flyctl creates two machines on an app's first deploy for
+      # high availability. A preview does not need zero-downtime deploys, and
+      # min_machines_running does not prevent it — that only sets how many stay
+      # running once idle, not how many get created.
       - name: Deploy
-        run: flyctl deploy --app "$APP" --config fly.preview.toml --remote-only
+        run: flyctl deploy --app "$APP" --config fly.preview.toml --remote-only --ha=false
 
       - name: Comment the preview URL
         env:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -60,6 +60,8 @@ jobs:
 
             https://zapp-atlas-pr-${{ github.event.pull_request.number }}.fly.dev
 
+            Built from ${{ github.event.pull_request.head.sha }}. If that isn't the head of this branch, the preview is mid-deploy or the last deploy failed — this comment is edited in place on every push, so it always names what is actually running.
+
             Sign in with the **Development sign-in** button on `/login` — it signs you in as the fake ORCID identity so the editing UI is usable. The "Sign in with ORCID iD" button does not work here.
 
             This app has no volume: the database resets to seed data whenever it redeploys or the machine idles down. It is destroyed when the PR closes or the `preview` label is removed.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -60,11 +60,13 @@ jobs:
 
             https://zapp-atlas-pr-${{ github.event.pull_request.number }}.fly.dev
 
-            Built from ${{ github.event.pull_request.head.sha }}. If that isn't the head of this branch, the preview is mid-deploy or the last deploy failed — this comment is edited in place on every push, so it always names what is actually running.
+            Built from ${{ github.event.pull_request.head.sha }}. (*If this is not the latest commit, then the last deploy failed or is in progress.*)
 
-            Sign in with the **Development sign-in** button on `/login` — it signs you in as the fake ORCID identity so the editing UI is usable. The "Sign in with ORCID iD" button does not work here.
+            ORCID authentication is not functional in previews. Instead, sign in with a test identity with the **Development sign-in** button on `/login`.
 
-            This app has no volume: the database resets to seed data whenever it redeploys or the machine idles down. It is destroyed when the PR closes or the `preview` label is removed.
+            Changes made in this preview are transient. The database will be reset to dummy seed data whenever the machine idles down (usually ~5 minutes).
+
+            The app will be destroyed when the PR closes, or the `preview` label is removed.
         run: gh pr comment "$PR" --edit-last --create-if-none --body "$BODY"
 
   destroy:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -53,18 +53,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
+          # One line per paragraph: GitHub renders single newlines in comments
+          # as hard breaks, so wrapping the source wraps the rendered comment.
           BODY: |
             ### Preview deployed
 
             https://zapp-atlas-pr-${{ github.event.pull_request.number }}.fly.dev
 
-            Sign in with the **Development sign-in** button on `/login` — it
-            signs you in as the fake ORCID identity so the editing UI is
-            usable. The "Sign in with ORCID iD" button does not work here.
+            Sign in with the **Development sign-in** button on `/login` — it signs you in as the fake ORCID identity so the editing UI is usable. The "Sign in with ORCID iD" button does not work here.
 
-            This app has no volume: the database resets to seed data whenever
-            it redeploys or the machine idles down. It is destroyed when the PR
-            closes or the `preview` label is removed.
+            This app has no volume: the database resets to seed data whenever it redeploys or the machine idles down. It is destroyed when the PR closes or the `preview` label is removed.
         run: gh pr comment "$PR" --edit-last --create-if-none --body "$BODY"
 
   destroy:
@@ -94,6 +92,5 @@ jobs:
           BODY: |
             ### Preview destroyed
 
-            The preview app for this PR has been torn down. Re-add the
-            `preview` label to bring it back.
+            The preview app for this PR has been torn down. Re-add the `preview` label to bring it back.
         run: gh pr comment "$PR" --edit-last --body "$BODY" || true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,95 @@
+name: Preview
+
+# Per-PR preview apps on Fly.io, opt-in via the `preview` label.
+#
+# Label a PR -> a `zapp-atlas-pr-<n>` app is created and deployed from
+# fly.preview.toml. Remove the label or close the PR -> the app is destroyed.
+# Pushes to a labelled PR redeploy the same app, so the URL never changes.
+#
+# Needs the FLY_PREVIEW_TOKEN secret: an *org*-scoped token, because creating
+# apps is beyond what the app-scoped FLY_API_TOKEN used by fly-deploy.yml can
+# do. Production deploys are unaffected by anything here.
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, synchronize, reopened, closed]
+
+env:
+  FLY_ORG: sabrina-toro
+  FLY_API_TOKEN: ${{ secrets.FLY_PREVIEW_TOKEN }}
+  APP: zapp-atlas-pr-${{ github.event.pull_request.number }}
+
+jobs:
+  deploy:
+    name: Deploy preview
+    # Fork PRs never receive secrets, so a preview could not be deployed for
+    # them; skip rather than fail. Closing is handled by the destroy job.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.action != 'closed'
+      && github.event.action != 'unlabeled'
+      && contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    concurrency:
+      group: preview-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: superfly/flyctl-actions/setup-flyctl@1.6
+
+      - name: Create the app if it does not exist
+        run: flyctl apps create "$APP" --org "$FLY_ORG" || true
+
+      - name: Deploy
+        run: flyctl deploy --app "$APP" --config fly.preview.toml --remote-only
+
+      - name: Comment the preview URL
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          BODY: |
+            ### Preview deployed
+
+            https://zapp-atlas-pr-${{ github.event.pull_request.number }}.fly.dev
+
+            Sign in with the **Development sign-in** button on `/login` — it
+            signs you in as the fake ORCID identity so the editing UI is
+            usable. The "Sign in with ORCID iD" button does not work here.
+
+            This app has no volume: the database resets to seed data whenever
+            it redeploys or the machine idles down. It is destroyed when the PR
+            closes or the `preview` label is removed.
+        run: gh pr comment "$PR" --edit-last --create-if-none --body "$BODY"
+
+  destroy:
+    name: Destroy preview
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && (github.event.action == 'closed'
+          || (github.event.action == 'unlabeled' && github.event.label.name == 'preview'))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    concurrency:
+      group: preview-${{ github.event.pull_request.number }}
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@1.6
+
+      # `|| true` so closing a PR that never had a preview is not a failure.
+      - name: Destroy the app
+        run: flyctl apps destroy "$APP" --yes || true
+
+      # No --create-if-none: if this PR never had a preview there is nothing to
+      # announce, and `|| true` keeps that from failing the job.
+      - name: Update the comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          BODY: |
+            ### Preview destroyed
+
+            The preview app for this PR has been torn down. Re-add the
+            `preview` label to bring it back.
+        run: gh pr comment "$PR" --edit-last --body "$BODY" || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,19 @@ is excluded and exempt.
 ## Signing in locally
 
 ORCID needs client credentials. For UI work, set `ZAPP_DEV_AUTH=true` instead:
-`/login` grows a form that signs in a fake identity via `POST /auth/dev/login`,
+`/login` grows a button that signs in a fake identity via `POST /auth/dev/login`,
 so signed-in states can be built without registering an app. It is off by
-default, 404s when off, and **must never be enabled in a deployment** — it hands
-a session cookie to anyone who asks.
+default and 404s when off.
+
+**It must never be enabled in production** — it hands a session cookie to anyone
+who asks. It *is* enabled deliberately in `fly.preview.toml`, which drives the
+per-PR preview apps: ORCID only redirects to pre-registered URIs, so it cannot
+work on a per-PR hostname, and a preview is worthless if reviewers have to
+bootstrap data by hand before seeing anything. Those apps hold nothing but
+throwaway seed data and are destroyed with the PR. Don't "fix" that config.
+
+The fake identity is Josiah Carberry (`0000-0002-1825-0097`) — ORCID's own
+canonical sample record, not an invention. Leave it be.
 
 Pages that need to know who is signed in should depend on `get_current_identity`
 (`auth/deps.py`) rather than reading the cookie directly.

--- a/fly.preview.toml
+++ b/fly.preview.toml
@@ -1,0 +1,54 @@
+# Fly config for per-PR preview apps. NOT production — see fly.toml for that.
+#
+# Used by .github/workflows/preview.yml, which deploys this against a per-PR
+# app (`zapp-atlas-pr-<n>`) and destroys it when the PR closes or loses its
+# `preview` label. Two deliberate differences from fly.toml:
+#
+#   * No [[mounts]]. Preview apps have no volume, so the database and uploads
+#     live on the machine's ephemeral rootfs. That is the point: a reviewer's
+#     edits disappear when the machine stops and it comes back with clean seed
+#     data. (get_engine() creates the parent directory, so /data need not be a
+#     real mount.)
+#   * ZAPP_DEV_AUTH is on. ORCID cannot work here — it only redirects to
+#     pre-registered URIs, and per-PR hostnames can't be registered — and a
+#     preview is only useful with data already in it. The one-click dev sign-in
+#     puts reviewers straight into the signed-in state. Safe only because these
+#     apps hold nothing but throwaway seed data and die with the PR.
+#
+# `app` is intentionally absent; the workflow passes --app per PR.
+
+primary_region = 'sjc'
+
+[build]
+
+[env]
+  ZAPP_DB_PATH = '/data/zapp.db'
+  ZAPP_UPLOAD_DIR = '/data/uploads'
+  ZAPP_DEV_AUTH = 'true'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  # Previews idle down to zero: stopped machines bill only for rootfs storage.
+  # Raising this to 1 would keep each open preview running around the clock.
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = 'requests'
+    hard_limit = 250
+    soft_limit = 200
+
+  [[http_service.checks]]
+    interval = '30s'
+    timeout = '5s'
+    grace_period = '10s'
+    method = 'GET'
+    path = '/health'
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 1024

--- a/server/src/zapp_atlas/html/templates/login.html
+++ b/server/src/zapp_atlas/html/templates/login.html
@@ -69,21 +69,19 @@
       </p>
 
       {#
-        Local development only, shown when ZAPP_DEV_AUTH=true. Signs in a fake
-        identity so the signed-in state can be worked on without ORCID
-        credentials. Never rendered in a deployment.
+        Shown when ZAPP_DEV_AUTH=true: local development, and the per-PR
+        preview apps deployed from fly.preview.toml, where ORCID cannot work.
+        Signs in a fake identity in one click; the route still accepts `name`
+        and `orcid_id` if you want a different one, so POST directly to
+        /auth/dev/login for that. Never enabled in production.
       #}
       {% if dev_auth %}
         <section class="login-card login-card--dev">
           <h2 class="login-card__title">Development sign-in</h2>
           <p>ORCID is bypassed because <code>ZAPP_DEV_AUTH</code> is enabled.</p>
           <form method="post" action="/auth/dev/login" class="login-dev-form">
-            <label for="dev-name">Name</label>
-            <input id="dev-name" name="name" value="Josiah Carberry">
-            <label for="dev-orcid">ORCID iD</label>
-            <input id="dev-orcid" name="orcid_id" value="0000-0002-1825-0097">
             <button type="submit" class="btn btn--primary login-card__submit">
-              Sign in as this user
+              Sign in as Josiah Carberry
             </button>
           </form>
         </section>

--- a/server/src/zapp_atlas/seed.py
+++ b/server/src/zapp_atlas/seed.py
@@ -12,9 +12,7 @@ Currently seeded:
 * **Nishi et al. 2025** (PMID:40359302) — BPA + retinoic acid co-exposure
   potentiates neural crest + hindbrain defects; AB background.
 * **Moreira et al. 2025** (PMID:41812223) — guanitoxin + organophosphate
-  co-exposure amplifies pericardial edema; generated end-to-end by
-  ``tests/curations/moreira-guanitoxin.spec.ts`` and exported via
-  ``just export-seed``.
+  co-exposure amplifies pericardial edema.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
This PR make deployment previews for PRs after the `preview` label has been added.

It works by spinning up a new PR-specific app on fly.io, which is destroyed when the PR is closed, or the label is removed.

Deployment previews use the dev authorization flag, which is now a one-click sign in. (ORCID authentication does not work on deployment previews). In a future PR, I'm going to flesh out the seed data some more, so that we can have a functional render.