### PR TITLE
Show member names by pre-populating OrcidIdentity when admins add members

### DIFF
--- a/server/src/zapp_atlas/api/dto.py
+++ b/server/src/zapp_atlas/api/dto.py
@@ -49,6 +49,8 @@ class MemberIn(BaseModel):
 class MemberOut(_FromAttributes):
     id: int
     member: str
+    # Display name from OrcidIdentity; null until one is known for this ORCID.
+    name: str | None = None
     role: ResearchGroupRoleEnum
     created_at: datetime | None
     updated_at: datetime | None

--- a/server/src/zapp_atlas/api/routers/research_groups.py
+++ b/server/src/zapp_atlas/api/routers/research_groups.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from zapp_atlas.api.authz import (
@@ -74,7 +74,10 @@ def list_members_endpoint(
     session: SessionDep,
     _: GroupMember,
 ) -> list[MemberOut]:
-    return [MemberOut.model_validate(m) for m in list_members(session, group_id)]
+    return [
+        MemberOut.model_validate(m).model_copy(update={"name": name})
+        for m, name in list_members(session, group_id)
+    ]
 
 
 @router.post(
@@ -86,10 +89,17 @@ def add_member_endpoint(
     group_id: int,
     payload: MemberIn,
     session: SessionDep,
+    request: Request,
     _: GroupAdmin,
 ) -> MemberOut:
-    membership = add_member(session, group_id, payload.member, payload.role.value)
-    return MemberOut.model_validate(membership)
+    membership, name = add_member(
+        session,
+        group_id,
+        payload.member,
+        payload.role.value,
+        name_lookup=request.app.state.orcid_name_lookup,
+    )
+    return MemberOut.model_validate(membership).model_copy(update={"name": name})
 
 
 @router.delete(
@@ -103,6 +113,4 @@ def remove_member_endpoint(
     _: GroupAdmin,
 ) -> None:
     if not remove_member(session, group_id, member_id):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Membership not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Membership not found")

--- a/server/src/zapp_atlas/api/services/research_groups.py
+++ b/server/src/zapp_atlas/api/services/research_groups.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from sqlalchemy.orm import Session
 
-from zapp_atlas.api.authz import orcid_curie
+from zapp_atlas.api.authz import ORCID_CURIE_PREFIX, orcid_curie
 from zapp_atlas.api.persistence import commit_or_conflict
 from zapp_atlas.auth.models import OrcidIdentity
+from zapp_atlas.auth.services import ensure_orcid_identity
 from zapp_atlas.schema.pydantic_crud import ResearchGroupRoleEnum
 from zapp_atlas.schema.sqla import ResearchGroup, ResearchGroupMember
 
@@ -41,9 +44,18 @@ def list_groups_for(session: Session, identity: OrcidIdentity) -> list[ResearchG
     )
 
 
-def list_members(session: Session, group_id: int) -> list[ResearchGroupMember]:
+def list_members(session: Session, group_id: int) -> list[tuple[ResearchGroupMember, str | None]]:
+    """Memberships with each member's display name, where one is known.
+
+    Membership stores an ``ORCID:`` CURIE while ``OrcidIdentity`` stores the
+    bare ORCID, so the outer join concatenates the prefix back on.
+    """
     return (
-        session.query(ResearchGroupMember)
+        session.query(ResearchGroupMember, OrcidIdentity.name)
+        .outerjoin(
+            OrcidIdentity,
+            ResearchGroupMember.member == ORCID_CURIE_PREFIX + OrcidIdentity.orcid_id,
+        )
         .filter(ResearchGroupMember.research_group == group_id)
         .order_by(ResearchGroupMember.id)
         .all()
@@ -51,15 +63,30 @@ def list_members(session: Session, group_id: int) -> list[ResearchGroupMember]:
 
 
 def add_member(
-    session: Session, group_id: int, member: str, role: str
-) -> ResearchGroupMember:
-    membership = ResearchGroupMember(
-        research_group=group_id, member=orcid_curie(member), role=role
-    )
+    session: Session,
+    group_id: int,
+    member: str,
+    role: str,
+    name_lookup: Callable[[str], str | None] | None = None,
+) -> tuple[ResearchGroupMember, str | None]:
+    """Add a member and make sure an ``OrcidIdentity`` exists for them.
+
+    The added person may never have logged in, so ``name_lookup`` (the ORCID
+    public API in production) supplies a display name for a newly created
+    identity. An identity that already exists keeps its name — that one came
+    from the person's own login.
+    """
+    curie = orcid_curie(member)
+    orcid_id = curie.removeprefix(ORCID_CURIE_PREFIX)
+    # Before the membership joins the session: ensure's SELECT would autoflush
+    # a duplicate membership and raise outside commit_or_conflict's 409.
+    identity = ensure_orcid_identity(session, orcid_id, name_lookup=name_lookup)
+
+    membership = ResearchGroupMember(research_group=group_id, member=curie, role=role)
     session.add(membership)
     commit_or_conflict(session, "That ORCID is already a member of this group")
     session.refresh(membership)
-    return membership
+    return membership, identity.name
 
 
 def remove_member(session: Session, group_id: int, member_id: int) -> bool:

--- a/server/src/zapp_atlas/auth/orcid_public.py
+++ b/server/src/zapp_atlas/auth/orcid_public.py
@@ -1,0 +1,52 @@
+"""Best-effort name lookup against the ORCID public API.
+
+Used to pre-populate ``OrcidIdentity`` when an admin adds a group member by
+ORCID, so the member has a display name before they ever log in themselves
+(#142). Failure is always an option here — no network, a private record, an
+unknown ORCID — and callers get ``None`` rather than an exception; the member's
+own login later stores the authoritative name.
+
+The app reaches this through ``app.state.orcid_name_lookup`` so tests can
+inject a stub instead of the network.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+PUBLIC_API_BASE = "https://pub.orcid.org/v3.0"
+TIMEOUT_SECONDS = 10
+
+
+def _value(section: dict[str, Any], key: str) -> str | None:
+    field = section.get(key)
+    if isinstance(field, dict):
+        return field.get("value")
+    return None
+
+
+def fetch_public_name(orcid_id: str) -> str | None:
+    """Return the public display name for a bare ORCID, or ``None``."""
+    request = Request(
+        f"{PUBLIC_API_BASE}/{orcid_id}/personal-details",
+        headers={"Accept": "application/json"},
+    )
+    try:
+        with urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+            details = json.loads(response.read().decode("utf-8"))
+    except (OSError, URLError, json.JSONDecodeError):
+        # OSError covers HTTPError and socket timeouts; URLError covers DNS
+        # and connection failures. None of them should break adding a member.
+        return None
+
+    name = details.get("name")
+    if not isinstance(name, dict):
+        return None
+    credit = _value(name, "credit-name")
+    if credit:
+        return credit
+    parts = [_value(name, "given-names"), _value(name, "family-name")]
+    return " ".join(part for part in parts if part) or None

--- a/server/src/zapp_atlas/auth/services.py
+++ b/server/src/zapp_atlas/auth/services.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import secrets
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -13,7 +14,6 @@ from sqlalchemy.orm import Session
 
 from zapp_atlas.auth.models import OrcidIdentity
 from zapp_atlas.settings import AppSettings, load_settings
-
 
 ORCID_STATE_COOKIE = "zapp_orcid_state"
 ORCID_AUTH_COOKIE = "zapp_orcid_auth"
@@ -48,9 +48,7 @@ def get_orcid_config(settings: AppSettings | None = None) -> OrcidConfig:
     client_id = settings.orcid_client_id
     client_secret = settings.orcid_client_secret
     if not client_id or not client_secret:
-        raise OrcidConfigError(
-            "ZAPP_ORCID_CLIENT_ID and ZAPP_ORCID_CLIENT_SECRET must be set"
-        )
+        raise OrcidConfigError("ZAPP_ORCID_CLIENT_ID and ZAPP_ORCID_CLIENT_SECRET must be set")
     return OrcidConfig(
         client_id=client_id,
         client_secret=client_secret,
@@ -125,10 +123,37 @@ def store_orcid_identity(session: Session, payload: dict[str, Any]) -> OrcidIden
         identity = OrcidIdentity(orcid_id=orcid_id)
         session.add(identity)
 
-    identity.name = payload.get("name")
+    # A payload without a name must not erase one we already hold — the row
+    # may have been pre-populated from the ORCID public API (#142).
+    name = payload.get("name")
+    if name:
+        identity.name = name
 
     session.commit()
     session.refresh(identity)
+    return identity
+
+
+def ensure_orcid_identity(
+    session: Session,
+    orcid_id: str,
+    name_lookup: Callable[[str], str | None] | None = None,
+) -> OrcidIdentity:
+    """Get or create the identity row for a bare ORCID, without committing.
+
+    An existing row is returned untouched — its name may come from the
+    person's own login, which outranks anything ``name_lookup`` would find, so
+    the lookup (typically a network call) only runs when a row is created.
+    """
+    identity = session.scalar(
+        select(OrcidIdentity)
+        .where(OrcidIdentity.orcid_id == orcid_id)
+        .order_by(OrcidIdentity.created_at)
+    )
+    if identity is None:
+        name = name_lookup(orcid_id) if name_lookup is not None else None
+        identity = OrcidIdentity(orcid_id=orcid_id, name=name)
+        session.add(identity)
     return identity
 
 

--- a/server/src/zapp_atlas/main.py
+++ b/server/src/zapp_atlas/main.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from fastapi import APIRouter, FastAPI
 from fastapi.staticfiles import StaticFiles
 
-from zapp_atlas.auth.router import router as auth_router
 from zapp_atlas.api.routers.cabinet import router as cabinet_router
 from zapp_atlas.api.routers.experiments import router as experiments_router
 from zapp_atlas.api.routers.exposures import router as exposures_router
@@ -22,12 +21,13 @@ from zapp_atlas.api.routers.images import router as images_router
 from zapp_atlas.api.routers.observations import router as observations_router
 from zapp_atlas.api.routers.research_groups import router as research_groups_router
 from zapp_atlas.api.routers.studies import router as studies_router
+from zapp_atlas.auth.orcid_public import fetch_public_name
+from zapp_atlas.auth.router import router as auth_router
 from zapp_atlas.db import get_engine, get_session_factory, init_db
 from zapp_atlas.html.edit_router import make_edit_router
 from zapp_atlas.html.router import router as html_router
 from zapp_atlas.seed import seed
 from zapp_atlas.settings import AppSettings, load_settings
-
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +59,9 @@ def create_app(settings: AppSettings | None = None) -> FastAPI:
         lifespan=lifespan,
     )
     app.state.settings = settings or load_settings()
+    # Resolves a bare ORCID to a public display name when admins add group
+    # members (#142). On app.state so tests can inject a stub for the network.
+    app.state.orcid_name_lookup = fetch_public_name
 
     @app.get("/health")
     def health() -> dict[str, str]:

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -30,6 +30,9 @@ def client(tmp_path) -> TestClient:
     # while passing on CI.
     settings = AppSettings(skip_seed=True, upload_dir=tmp_path, _env_file=None)
     app = create_app(settings)
+    # Never let tests reach the ORCID public API; individual tests replace this
+    # stub when they care about the looked-up name.
+    app.state.orcid_name_lookup = lambda orcid_id: None
 
     def _override_get_session():
         session = SessionLocal()

--- a/server/tests/test_api_member_names.py
+++ b/server/tests/test_api_member_names.py
@@ -1,0 +1,110 @@
+"""Member names on the research-group membership API (#142).
+
+``ResearchGroupMember`` stores only an ORCID CURIE and a role; human names live
+on ``OrcidIdentity``. These tests cover how names reach the membership
+responses: from a member's own login, and — for members added by ORCID before
+they ever sign in — from the ORCID public API via the app's name lookup
+(``app.state.orcid_name_lookup``, stubbed out in the test client).
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+ADMIN = "0000-0002-1825-0097"
+NEW_MEMBER = "0000-0001-1111-2222"
+
+
+def signin(client: TestClient, orcid_id: str, name: str = "Test User") -> None:
+    client.app.state.settings.dev_auth = True
+    res = client.post(
+        "/auth/dev/login",
+        data={"orcid_id": orcid_id, "name": name},
+        follow_redirects=False,
+    )
+    assert res.status_code in (303, 307)
+
+
+def make_group(client: TestClient, name: str = "Test Lab") -> int:
+    signin(client, ADMIN, name="Josiah Carberry")
+    res = client.post("/api/research-groups", json={"name": name})
+    assert res.status_code == 201, res.text
+    return res.json()["id"]
+
+
+def test_members_listing_names_a_member_who_has_logged_in(client: TestClient) -> None:
+    group_id = make_group(client)
+    members = client.get(f"/api/research-groups/{group_id}/members").json()
+    assert members[0]["member"] == f"ORCID:{ADMIN}"
+    assert members[0]["name"] == "Josiah Carberry"
+
+
+def test_adding_a_member_prefetches_their_public_name(client: TestClient) -> None:
+    group_id = make_group(client)
+    client.app.state.orcid_name_lookup = lambda orcid_id: "Divya Example"
+
+    res = client.post(
+        f"/api/research-groups/{group_id}/members",
+        json={"member": NEW_MEMBER, "role": "member"},
+    )
+    assert res.status_code == 201, res.text
+    assert res.json()["name"] == "Divya Example"
+
+    # The name is stored, not merely echoed: the listing (which resolves names
+    # through OrcidIdentity) shows it before the member has ever logged in.
+    members = client.get(f"/api/research-groups/{group_id}/members").json()
+    by_orcid = {m["member"]: m["name"] for m in members}
+    assert by_orcid[f"ORCID:{NEW_MEMBER}"] == "Divya Example"
+
+
+def test_member_is_added_even_when_no_public_name_is_found(client: TestClient) -> None:
+    # A private or unknown ORCID record yields no name; the add must still work.
+    group_id = make_group(client)
+    client.app.state.orcid_name_lookup = lambda orcid_id: None
+
+    res = client.post(
+        f"/api/research-groups/{group_id}/members",
+        json={"member": NEW_MEMBER, "role": "member"},
+    )
+    assert res.status_code == 201, res.text
+    assert res.json()["name"] is None
+
+
+def test_adding_a_member_who_already_logged_in_keeps_their_login_name(
+    client: TestClient,
+) -> None:
+    group_id = make_group(client)
+    # They logged in themselves at some point: that name is authoritative.
+    signin(client, NEW_MEMBER, name="Dr. Divya Example")
+
+    lookups: list[str] = []
+
+    def lookup(orcid_id: str) -> str:
+        lookups.append(orcid_id)
+        return "Stale Public Name"
+
+    client.app.state.orcid_name_lookup = lookup
+    signin(client, ADMIN, name="Josiah Carberry")
+    res = client.post(
+        f"/api/research-groups/{group_id}/members",
+        json={"member": NEW_MEMBER, "role": "member"},
+    )
+    assert res.status_code == 201, res.text
+    assert res.json()["name"] == "Dr. Divya Example"
+    assert lookups == []  # no pointless network call for a known identity
+
+
+def test_login_name_replaces_the_prefetched_public_name(client: TestClient) -> None:
+    group_id = make_group(client)
+    client.app.state.orcid_name_lookup = lambda orcid_id: "D. Example"
+    res = client.post(
+        f"/api/research-groups/{group_id}/members",
+        json={"member": NEW_MEMBER, "role": "member"},
+    )
+    assert res.json()["name"] == "D. Example"
+
+    # The member signs in themselves; their own login name is authoritative.
+    signin(client, NEW_MEMBER, name="Divya Example")
+    members = client.get(f"/api/research-groups/{group_id}/members").json()
+    by_orcid = {m["member"]: m["name"] for m in members}
+    assert by_orcid[f"ORCID:{NEW_MEMBER}"] == "Divya Example"

--- a/server/tests/test_auth_orcid.py
+++ b/server/tests/test_auth_orcid.py
@@ -203,6 +203,35 @@ def test_store_orcid_identity_updates_existing_identity() -> None:
     assert second.name == "Dr. Sofia Garcia"
 
 
+def test_store_orcid_identity_keeps_prefetched_name_when_login_has_none() -> None:
+    # An admin adding this person to a group may have pre-populated their
+    # identity from the ORCID public API (#142); a token payload that carries
+    # no name must not erase that.
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    init_db(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        session.add(OrcidIdentity(orcid_id="0000-0001-2345-6789", name="Sofia Garcia"))
+        session.commit()
+
+        identity = store_orcid_identity(
+            session,
+            {
+                "access_token": "access-token",
+                "token_type": "bearer",
+                "scope": "/authenticate",
+                "orcid": "0000-0001-2345-6789",
+            },
+        )
+
+    assert identity.name == "Sofia Garcia"
+
+
 def test_orcid_identity_table_is_registered_with_init_db() -> None:
     engine = create_engine(
         "sqlite:///:memory:",

--- a/server/tests/test_orcid_public.py
+++ b/server/tests/test_orcid_public.py
@@ -1,0 +1,80 @@
+"""Unit tests for the best-effort ORCID public API name lookup (#142)."""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+
+from zapp_atlas.auth.orcid_public import fetch_public_name
+
+CARBERRY = "0000-0002-1825-0097"
+
+
+@contextmanager
+def _response(payload: dict) -> io.BytesIO:
+    yield io.BytesIO(json.dumps(payload).encode("utf-8"))
+
+
+def _personal_details(
+    given: str | None = None, family: str | None = None, credit: str | None = None
+) -> dict:
+    def value(v: str | None) -> dict | None:
+        return {"value": v} if v is not None else None
+
+    return {
+        "name": {
+            "given-names": value(given),
+            "family-name": value(family),
+            "credit-name": value(credit),
+        }
+    }
+
+
+def test_prefers_the_credit_name() -> None:
+    payload = _personal_details(given="Josiah", family="Carberry", credit="J. S. Carberry")
+    with patch("zapp_atlas.auth.orcid_public.urlopen", return_value=_response(payload)) as urlopen:
+        name = fetch_public_name(CARBERRY)
+
+    assert name == "J. S. Carberry"
+    (request,), _ = urlopen.call_args
+    assert request.full_url == f"https://pub.orcid.org/v3.0/{CARBERRY}/personal-details"
+
+
+def test_falls_back_to_given_and_family_names() -> None:
+    payload = _personal_details(given="Josiah", family="Carberry")
+    with patch("zapp_atlas.auth.orcid_public.urlopen", return_value=_response(payload)):
+        assert fetch_public_name(CARBERRY) == "Josiah Carberry"
+
+
+def test_uses_given_name_alone_when_family_name_is_withheld() -> None:
+    payload = _personal_details(given="Josiah")
+    with patch("zapp_atlas.auth.orcid_public.urlopen", return_value=_response(payload)):
+        assert fetch_public_name(CARBERRY) == "Josiah"
+
+
+def test_private_record_yields_none() -> None:
+    with patch("zapp_atlas.auth.orcid_public.urlopen", return_value=_response({"name": None})):
+        assert fetch_public_name(CARBERRY) is None
+
+
+def test_http_error_yields_none() -> None:
+    error = HTTPError(url="...", code=404, msg="Not Found", hdrs=None, fp=None)
+    with patch("zapp_atlas.auth.orcid_public.urlopen", side_effect=error):
+        assert fetch_public_name(CARBERRY) is None
+
+
+def test_network_error_yields_none() -> None:
+    with patch("zapp_atlas.auth.orcid_public.urlopen", side_effect=URLError("no route")):
+        assert fetch_public_name(CARBERRY) is None
+
+
+def test_malformed_body_yields_none() -> None:
+    @contextmanager
+    def garbage():
+        yield io.BytesIO(b"<html>not json</html>")
+
+    with patch("zapp_atlas.auth.orcid_public.urlopen", return_value=garbage()):
+        assert fetch_public_name(CARBERRY) is None


### PR DESCRIPTION
Closes #142.

A `ResearchGroupMember` stores only an ORCID CURIE and a role, and the only writer of `OrcidIdentity.name` was the person's own login — so a member added by ORCID displayed as a raw CURIE until they happened to sign in themselves.

## What changed

- **Adding a member ensures an `OrcidIdentity` row exists for them** (`ensure_orcid_identity` in `auth/services.py`), filling its name best-effort from the ORCID public API (`auth/orcid_public.py`: anonymous `pub.orcid.org` lookup; credit name preferred, else given + family). Lookup failures and private records leave the name null rather than blocking the add.
- **A name from a real login is authoritative.** The lookup only runs when no identity exists yet, and the login path no longer clobbers a prefetched name when the token payload carries none. When the person eventually signs in, `store_orcid_identity` finds the pre-created row by `orcid_id` and updates it in place — no duplicates.
- **`MemberOut` grows a nullable `name`**, resolved by outer-joining memberships to `OrcidIdentity`, so both `GET` and `POST /api/research-groups/{id}/members` return it.
- The lookup is injected via `app.state.orcid_name_lookup`; the test client stubs it so tests never touch the network.

## Testing

Built test-first: 11 new tests across `test_api_member_names.py` (API behavior), `test_orcid_public.py` (public-API parsing and failure modes, mocked HTTP), and `test_auth_orcid.py` (login/prefetch interaction). Also live-verified the lookup resolves `0000-0002-1825-0097` → "Josiah Carberry" anonymously.

Note: the QC check will stay red until #143 (repo-wide ruff cleanup) merges — `main` itself doesn't pass the locked ruff 0.16.1. The files in this PR are individually clean under it.

https://claude.ai/code/session_01WgG17Pah7TaRFDbkKodF1x